### PR TITLE
Support for synchronizing schema change events from MySQL to PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>3.3.2</kafka.version>
         <kafka.scala.version>2.13</kafka.scala.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.antlr>4.10.1</version.antlr>
+        <antlr.source.directory>${project.basedir}/src/main/antlr4</antlr.source.directory>
     </properties>
     <dependencies>
         <dependency>
@@ -52,13 +55,43 @@
             <artifactId>elasticsearch-java</artifactId>
             <version>8.8.2</version>
         </dependency>
-
         <!-- https://mvnrepository.com/artifact/net.openhft/zero-allocation-hashing -->
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>zero-allocation-hashing</artifactId>
             <version>0.16</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${version.antlr}</version>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${version.antlr}</version>
+                <configuration>
+                    <sourceDirectory>${antlr.source.directory}</sourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/antlr4/io/dbsink/connector/sink/ddl/parser/mysql/MySqlLexer.g4
+++ b/src/main/antlr4/io/dbsink/connector/sink/ddl/parser/mysql/MySqlLexer.g4
@@ -1,0 +1,1358 @@
+/*
+MySQL (Positive Technologies) grammar
+The MIT License (MIT).
+Copyright (c) 2015-2017, Ivan Kochurkin (kvanttt@gmail.com), Positive Technologies.
+Copyright (c) 2017, Ivan Khudyashev (IHudyashov@ptsecurity.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+lexer grammar MySqlLexer;
+
+options { caseInsensitive = true; }
+
+channels { MYSQLCOMMENT, ERRORCHANNEL }
+
+// SKIP
+
+SPACE:                               [ \t\r\n]+    -> channel(HIDDEN);
+SPEC_MYSQL_COMMENT:                  '/*!' .+? '*/' -> channel(MYSQLCOMMENT);
+COMMENT_INPUT:                       '/*' .*? '*/' -> channel(HIDDEN);
+LINE_COMMENT:                        (
+                                       ('--' [ \t]* | '#') ~[\r\n]* ('\r'? '\n' | EOF)
+                                       | '--' ('\r'? '\n' | EOF)
+                                     ) -> channel(HIDDEN);
+
+
+// Keywords
+// Common Keywords
+
+ADD:                                 'ADD';
+ALL:                                 'ALL';
+ALTER:                               'ALTER';
+ALWAYS:                              'ALWAYS';
+ANALYZE:                             'ANALYZE';
+AND:                                 'AND';
+ARRAY:                               'ARRAY';
+AS:                                  'AS';
+ASC:                                 'ASC';
+ATTRIBUTE:                           'ATTRIBUTE';
+BEFORE:                              'BEFORE';
+BETWEEN:                             'BETWEEN';
+BOTH:                                'BOTH';
+BUCKETS:                             'BUCKETS';
+BY:                                  'BY';
+CALL:                                'CALL';
+CASCADE:                             'CASCADE';
+CASE:                                'CASE';
+CAST:                                'CAST';
+CHANGE:                              'CHANGE';
+CHARACTER:                           'CHARACTER';
+CHECK:                               'CHECK';
+COLLATE:                             'COLLATE';
+COLUMN:                              'COLUMN';
+CONDITION:                           'CONDITION';
+CONSTRAINT:                          'CONSTRAINT';
+CONTINUE:                            'CONTINUE';
+CONVERT:                             'CONVERT';
+CREATE:                              'CREATE';
+CROSS:                               'CROSS';
+CURRENT:                             'CURRENT';
+CURRENT_ROLE:                        'CURRENT_ROLE';
+CURRENT_USER:                        'CURRENT_USER';
+CURSOR:                              'CURSOR';
+DATABASE:                            'DATABASE';
+DATABASES:                           'DATABASES';
+DECLARE:                             'DECLARE';
+DEFAULT:                             'DEFAULT';
+DELAYED:                             'DELAYED';
+DELETE:                              'DELETE';
+DESC:                                'DESC';
+DESCRIBE:                            'DESCRIBE';
+DETERMINISTIC:                       'DETERMINISTIC';
+DIAGNOSTICS:                         'DIAGNOSTICS';
+DISTINCT:                            'DISTINCT';
+DISTINCTROW:                         'DISTINCTROW';
+DROP:                                'DROP';
+EACH:                                'EACH';
+ELSE:                                'ELSE';
+ELSEIF:                              'ELSEIF';
+EMPTY:                               'EMPTY';
+ENCLOSED:                            'ENCLOSED';
+ENFORCED:                            'ENFORCED';
+ESCAPED:                             'ESCAPED';
+EXCEPT:                              'EXCEPT';
+EXISTS:                              'EXISTS';
+EXIT:                                'EXIT';
+EXPLAIN:                             'EXPLAIN';
+FALSE:                               'FALSE';
+FETCH:                               'FETCH';
+FOR:                                 'FOR';
+FORCE:                               'FORCE';
+FOREIGN:                             'FOREIGN';
+FROM:                                'FROM';
+FULLTEXT:                            'FULLTEXT';
+GENERATED:                           'GENERATED';
+GET:                                 'GET';
+GRANT:                               'GRANT';
+GROUP:                               'GROUP';
+HAVING:                              'HAVING';
+HIGH_PRIORITY:                       'HIGH_PRIORITY';
+HISTOGRAM:                           'HISTOGRAM';
+IF:                                  'IF';
+IGNORE:                              'IGNORE';
+IGNORED:                             'IGNORED';
+IN:                                  'IN';
+INDEX:                               'INDEX';
+INFILE:                              'INFILE';
+INNER:                               'INNER';
+INOUT:                               'INOUT';
+INSERT:                              'INSERT';
+INTERVAL:                            'INTERVAL';
+INTO:                                'INTO';
+IS:                                  'IS';
+ITERATE:                             'ITERATE';
+JOIN:                                'JOIN';
+KEY:                                 'KEY';
+KEYS:                                'KEYS';
+KILL:                                'KILL';
+LATERAL:                             'LATERAL';
+LEADING:                             'LEADING';
+LEAVE:                               'LEAVE';
+LEFT:                                'LEFT';
+LIKE:                                'LIKE';
+LIMIT:                               'LIMIT';
+LINEAR:                              'LINEAR';
+LINES:                               'LINES';
+LOAD:                                'LOAD';
+LOCK:                                'LOCK';
+LOCKED:                              'LOCKED';
+LOOP:                                'LOOP';
+LOW_PRIORITY:                        'LOW_PRIORITY';
+MASTER_BIND:                         'MASTER_BIND';
+MASTER_SSL_VERIFY_SERVER_CERT:       'MASTER_SSL_VERIFY_SERVER_CERT';
+MATCH:                               'MATCH';
+MAXVALUE:                            'MAXVALUE';
+MINVALUE:                            'MINVALUE';
+MODIFIES:                            'MODIFIES';
+NATURAL:                             'NATURAL';
+NOT:                                 'NOT';
+NO_WRITE_TO_BINLOG:                  'NO_WRITE_TO_BINLOG';
+NULL_LITERAL:                        'NULL';
+NUMBER:                              'NUMBER';
+ON:                                  'ON';
+OPTIMIZE:                            'OPTIMIZE';
+OPTION:                              'OPTION';
+OPTIONAL:                            'OPTIONAL';
+OPTIONALLY:                          'OPTIONALLY';
+OR:                                  'OR';
+ORDER:                               'ORDER';
+OUT:                                 'OUT';
+OUTER:                               'OUTER';
+OUTFILE:                             'OUTFILE';
+OVER:                                'OVER';
+PARTITION:                           'PARTITION';
+PRIMARY:                             'PRIMARY';
+PROCEDURE:                           'PROCEDURE';
+PURGE:                               'PURGE';
+RANGE:                               'RANGE';
+READ:                                'READ';
+READS:                               'READS';
+REFERENCES:                          'REFERENCES';
+REGEXP:                              'REGEXP';
+RELEASE:                             'RELEASE';
+RENAME:                              'RENAME';
+REPEAT:                              'REPEAT';
+REPLACE:                             'REPLACE';
+REQUIRE:                             'REQUIRE';
+RESIGNAL:                            'RESIGNAL';
+RESTRICT:                            'RESTRICT';
+RETAIN:                              'RETAIN';
+RETURN:                              'RETURN';
+REVOKE:                              'REVOKE';
+RIGHT:                               'RIGHT';
+RLIKE:                               'RLIKE';
+SCHEMA:                              'SCHEMA';
+SCHEMAS:                             'SCHEMAS';
+SELECT:                              'SELECT';
+SET:                                 'SET';
+SEPARATOR:                           'SEPARATOR';
+SHOW:                                'SHOW';
+SIGNAL:                              'SIGNAL';
+SKIP_:                               'SKIP';
+SPATIAL:                             'SPATIAL';
+SQL:                                 'SQL';
+SQLEXCEPTION:                        'SQLEXCEPTION';
+SQLSTATE:                            'SQLSTATE';
+SQLWARNING:                          'SQLWARNING';
+SQL_BIG_RESULT:                      'SQL_BIG_RESULT';
+SQL_CALC_FOUND_ROWS:                 'SQL_CALC_FOUND_ROWS';
+SQL_SMALL_RESULT:                    'SQL_SMALL_RESULT';
+SSL:                                 'SSL';
+STACKED:                             'STACKED';
+STARTING:                            'STARTING';
+STATEMENT:                           'STATEMENT';
+STRAIGHT_JOIN:                       'STRAIGHT_JOIN';
+TABLE:                               'TABLE';
+TERMINATED:                          'TERMINATED';
+THEN:                                'THEN';
+TO:                                  'TO';
+TRAILING:                            'TRAILING';
+TRIGGER:                             'TRIGGER';
+TRUE:                                'TRUE';
+UNDO:                                'UNDO';
+UNION:                               'UNION';
+UNIQUE:                              'UNIQUE';
+UNLOCK:                              'UNLOCK';
+UNSIGNED:                            'UNSIGNED';
+UPDATE:                              'UPDATE';
+USAGE:                               'USAGE';
+USE:                                 'USE';
+USING:                               'USING';
+VALUES:                              'VALUES';
+WHEN:                                'WHEN';
+WHERE:                               'WHERE';
+WHILE:                               'WHILE';
+WITH:                                'WITH';
+WRITE:                               'WRITE';
+XOR:                                 'XOR';
+ZEROFILL:                            'ZEROFILL';
+
+// DATA TYPE Keywords
+
+TINYINT:                             'TINYINT';
+SMALLINT:                            'SMALLINT';
+MEDIUMINT:                           'MEDIUMINT';
+MIDDLEINT:                           'MIDDLEINT';
+INT:                                 'INT';
+INT1:                                'INT1';
+INT2:                                'INT2';
+INT3:                                'INT3';
+INT4:                                'INT4';
+INT8:                                'INT8';
+INTEGER:                             'INTEGER';
+BIGINT:                              'BIGINT';
+REAL:                                'REAL';
+DOUBLE:                              'DOUBLE';
+PRECISION:                           'PRECISION';
+FLOAT:                               'FLOAT';
+FLOAT4:                              'FLOAT4';
+FLOAT8:                              'FLOAT8';
+DECIMAL:                             'DECIMAL';
+DEC:                                 'DEC';
+NUMERIC:                             'NUMERIC';
+DATE:                                'DATE';
+TIME:                                'TIME';
+TIMESTAMP:                           'TIMESTAMP';
+DATETIME:                            'DATETIME';
+YEAR:                                'YEAR';
+CHAR:                                'CHAR';
+VARCHAR:                             'VARCHAR';
+NVARCHAR:                            'NVARCHAR';
+NATIONAL:                            'NATIONAL';
+BINARY:                              'BINARY';
+VARBINARY:                           'VARBINARY';
+TINYBLOB:                            'TINYBLOB';
+BLOB:                                'BLOB';
+MEDIUMBLOB:                          'MEDIUMBLOB';
+LONG:                                'LONG';
+LONGBLOB:                            'LONGBLOB';
+TINYTEXT:                            'TINYTEXT';
+TEXT:                                'TEXT';
+MEDIUMTEXT:                          'MEDIUMTEXT';
+LONGTEXT:                            'LONGTEXT';
+ENUM:                                'ENUM';
+VARYING:                             'VARYING';
+SERIAL:                              'SERIAL';
+
+
+// Interval type Keywords
+
+YEAR_MONTH:                          'YEAR_MONTH';
+DAY_HOUR:                            'DAY_HOUR';
+DAY_MINUTE:                          'DAY_MINUTE';
+DAY_SECOND:                          'DAY_SECOND';
+HOUR_MINUTE:                         'HOUR_MINUTE';
+HOUR_SECOND:                         'HOUR_SECOND';
+MINUTE_SECOND:                       'MINUTE_SECOND';
+SECOND_MICROSECOND:                  'SECOND_MICROSECOND';
+MINUTE_MICROSECOND:                  'MINUTE_MICROSECOND';
+HOUR_MICROSECOND:                    'HOUR_MICROSECOND';
+DAY_MICROSECOND:                     'DAY_MICROSECOND';
+
+// JSON keywords
+JSON_ARRAY:                          'JSON_ARRAY';
+JSON_ARRAYAGG:                       'JSON_ARRAYAGG';
+JSON_ARRAY_APPEND:                   'JSON_ARRAY_APPEND';
+JSON_ARRAY_INSERT:                   'JSON_ARRAY_INSERT';
+JSON_CONTAINS:                       'JSON_CONTAINS';
+JSON_CONTAINS_PATH:                  'JSON_CONTAINS_PATH';
+JSON_DEPTH:                          'JSON_DEPTH';
+JSON_EXTRACT:                        'JSON_EXTRACT';
+JSON_INSERT:                         'JSON_INSERT';
+JSON_KEYS:                           'JSON_KEYS';
+JSON_LENGTH:                         'JSON_LENGTH';
+JSON_MERGE:                          'JSON_MERGE';
+JSON_MERGE_PATCH:                    'JSON_MERGE_PATCH';
+JSON_MERGE_PRESERVE:                 'JSON_MERGE_PRESERVE';
+JSON_OBJECT:                         'JSON_OBJECT';
+JSON_OBJECTAGG:                      'JSON_OBJECTAGG';
+JSON_OVERLAPS:                       'JSON_OVERLAPS';
+JSON_PRETTY:                         'JSON_PRETTY';
+JSON_QUOTE:                          'JSON_QUOTE';
+JSON_REMOVE:                         'JSON_REMOVE';
+JSON_REPLACE:                        'JSON_REPLACE';
+JSON_SCHEMA_VALID:                   'JSON_SCHEMA_VALID';
+JSON_SCHEMA_VALIDATION_REPORT:       'JSON_SCHEMA_VALIDATION_REPORT';
+JSON_SEARCH:                         'JSON_SEARCH';
+JSON_SET:                            'JSON_SET';
+JSON_STORAGE_FREE:                   'JSON_STORAGE_FREE';
+JSON_STORAGE_SIZE:                   'JSON_STORAGE_SIZE';
+JSON_TABLE:                          'JSON_TABLE';
+JSON_TYPE:                           'JSON_TYPE';
+JSON_UNQUOTE:                        'JSON_UNQUOTE';
+JSON_VALID:                          'JSON_VALID';
+JSON_VALUE:                          'JSON_VALUE';
+NESTED:                              'NESTED';
+ORDINALITY:                          'ORDINALITY';
+PATH:                                'PATH';
+
+// Group function Keywords
+
+AVG:                                 'AVG';
+BIT_AND:                             'BIT_AND';
+BIT_OR:                              'BIT_OR';
+BIT_XOR:                             'BIT_XOR';
+COUNT:                               'COUNT';
+CUME_DIST:                           'CUME_DIST';
+DENSE_RANK:                          'DENSE_RANK';
+FIRST_VALUE:                         'FIRST_VALUE';
+GROUP_CONCAT:                        'GROUP_CONCAT';
+LAG:                                 'LAG';
+LAST_VALUE:                          'LAST_VALUE';
+LEAD:                                'LEAD';
+MAX:                                 'MAX';
+MIN:                                 'MIN';
+NTILE:                               'NTILE';
+NTH_VALUE:                           'NTH_VALUE';
+PERCENT_RANK:                        'PERCENT_RANK';
+RANK:                                'RANK';
+ROW_NUMBER:                          'ROW_NUMBER';
+STD:                                 'STD';
+STDDEV:                              'STDDEV';
+STDDEV_POP:                          'STDDEV_POP';
+STDDEV_SAMP:                         'STDDEV_SAMP';
+SUM:                                 'SUM';
+VAR_POP:                             'VAR_POP';
+VAR_SAMP:                            'VAR_SAMP';
+VARIANCE:                            'VARIANCE';
+
+// Common function Keywords
+
+CURRENT_DATE:                        'CURRENT_DATE';
+CURRENT_TIME:                        'CURRENT_TIME';
+CURRENT_TIMESTAMP:                   'CURRENT_TIMESTAMP';
+LOCALTIME:                           'LOCALTIME';
+CURDATE:                             'CURDATE';
+CURTIME:                             'CURTIME';
+DATE_ADD:                            'DATE_ADD';
+DATE_SUB:                            'DATE_SUB';
+EXTRACT:                             'EXTRACT';
+LOCALTIMESTAMP:                      'LOCALTIMESTAMP';
+NOW:                                 'NOW';
+POSITION:                            'POSITION';
+SUBSTR:                              'SUBSTR';
+SUBSTRING:                           'SUBSTRING';
+SYSDATE:                             'SYSDATE';
+TRIM:                                'TRIM';
+UTC_DATE:                            'UTC_DATE';
+UTC_TIME:                            'UTC_TIME';
+UTC_TIMESTAMP:                       'UTC_TIMESTAMP';
+
+// Keywords, but can be ID
+// Common Keywords, but can be ID
+
+ACCOUNT:                             'ACCOUNT';
+ACTION:                              'ACTION';
+AFTER:                               'AFTER';
+AGGREGATE:                           'AGGREGATE';
+ALGORITHM:                           'ALGORITHM';
+ANY:                                 'ANY';
+AT:                                  'AT';
+AUTHORS:                             'AUTHORS';
+AUTOCOMMIT:                          'AUTOCOMMIT';
+AUTOEXTEND_SIZE:                     'AUTOEXTEND_SIZE';
+AUTO_INCREMENT:                      'AUTO_INCREMENT';
+AVG_ROW_LENGTH:                      'AVG_ROW_LENGTH';
+BEGIN:                               'BEGIN';
+BINLOG:                              'BINLOG';
+BIT:                                 'BIT';
+BLOCK:                               'BLOCK';
+BOOL:                                'BOOL';
+BOOLEAN:                             'BOOLEAN';
+BTREE:                               'BTREE';
+CACHE:                               'CACHE';
+CASCADED:                            'CASCADED';
+CHAIN:                               'CHAIN';
+CHANGED:                             'CHANGED';
+CHANNEL:                             'CHANNEL';
+CHECKSUM:                            'CHECKSUM';
+PAGE_CHECKSUM:                       'PAGE_CHECKSUM';
+CIPHER:                              'CIPHER';
+CLASS_ORIGIN:                        'CLASS_ORIGIN';
+CLIENT:                              'CLIENT';
+CLOSE:                               'CLOSE';
+CLUSTERING:                          'CLUSTERING';
+COALESCE:                            'COALESCE';
+CODE:                                'CODE';
+COLUMNS:                             'COLUMNS';
+COLUMN_FORMAT:                       'COLUMN_FORMAT';
+COLUMN_NAME:                         'COLUMN_NAME';
+COMMENT:                             'COMMENT';
+COMMIT:                              'COMMIT';
+COMPACT:                             'COMPACT';
+COMPLETION:                          'COMPLETION';
+COMPRESSED:                          'COMPRESSED';
+COMPRESSION:                         'COMPRESSION' | QUOTE_SYMB? 'COMPRESSION' QUOTE_SYMB?;
+CONCURRENT:                          'CONCURRENT';
+CONNECT:                             'CONNECT';
+CONNECTION:                          'CONNECTION';
+CONSISTENT:                          'CONSISTENT';
+CONSTRAINT_CATALOG:                  'CONSTRAINT_CATALOG';
+CONSTRAINT_SCHEMA:                   'CONSTRAINT_SCHEMA';
+CONSTRAINT_NAME:                     'CONSTRAINT_NAME';
+CONTAINS:                            'CONTAINS';
+CONTEXT:                             'CONTEXT';
+CONTRIBUTORS:                        'CONTRIBUTORS';
+COPY:                                'COPY';
+CPU:                                 'CPU';
+CYCLE:                               'CYCLE';
+CURSOR_NAME:                         'CURSOR_NAME';
+DATA:                                'DATA';
+DATAFILE:                            'DATAFILE';
+DEALLOCATE:                          'DEALLOCATE';
+DEFAULT_AUTH:                        'DEFAULT_AUTH';
+DEFINER:                             'DEFINER';
+DELAY_KEY_WRITE:                     'DELAY_KEY_WRITE';
+DES_KEY_FILE:                        'DES_KEY_FILE';
+DIRECTORY:                           'DIRECTORY';
+DISABLE:                             'DISABLE';
+DISCARD:                             'DISCARD';
+DISK:                                'DISK';
+DO:                                  'DO';
+DUMPFILE:                            'DUMPFILE';
+DUPLICATE:                           'DUPLICATE';
+DYNAMIC:                             'DYNAMIC';
+ENABLE:                              'ENABLE';
+ENCRYPTED:                           'ENCRYPTED';
+ENCRYPTION:                          'ENCRYPTION';
+ENCRYPTION_KEY_ID:                   'ENCRYPTION_KEY_ID';
+END:                                 'END';
+ENDS:                                'ENDS';
+ENGINE:                              'ENGINE';
+ENGINES:                             'ENGINES';
+ERROR:                               'ERROR';
+ERRORS:                              'ERRORS';
+ESCAPE:                              'ESCAPE';
+EVEN:                                'EVEN';
+EVENT:                               'EVENT';
+EVENTS:                              'EVENTS';
+EVERY:                               'EVERY';
+EXCHANGE:                            'EXCHANGE';
+EXCLUSIVE:                           'EXCLUSIVE';
+EXPIRE:                              'EXPIRE';
+EXPORT:                              'EXPORT';
+EXTENDED:                            'EXTENDED';
+EXTENT_SIZE:                         'EXTENT_SIZE';
+FAILED_LOGIN_ATTEMPTS:               'FAILED_LOGIN_ATTEMPTS';
+FAST:                                'FAST';
+FAULTS:                              'FAULTS';
+FIELDS:                              'FIELDS';
+FILE_BLOCK_SIZE:                     'FILE_BLOCK_SIZE';
+FILTER:                              'FILTER';
+FIRST:                               'FIRST';
+FIXED:                               'FIXED';
+FLUSH:                               'FLUSH';
+FOLLOWING:                           'FOLLOWING';
+FOLLOWS:                             'FOLLOWS';
+FOUND:                               'FOUND';
+FULL:                                'FULL';
+FUNCTION:                            'FUNCTION';
+GENERAL:                             'GENERAL';
+GLOBAL:                              'GLOBAL';
+GRANTS:                              'GRANTS';
+GROUP_REPLICATION:                   'GROUP_REPLICATION';
+HANDLER:                             'HANDLER';
+HASH:                                'HASH';
+HELP:                                'HELP';
+HISTORY:                             'HISTORY';
+HOST:                                'HOST';
+HOSTS:                               'HOSTS';
+IDENTIFIED:                          'IDENTIFIED';
+IGNORE_SERVER_IDS:                   'IGNORE_SERVER_IDS';
+IMPORT:                              'IMPORT';
+INCREMENT:                           'INCREMENT';
+INDEXES:                             'INDEXES';
+INITIAL_SIZE:                        'INITIAL_SIZE';
+INPLACE:                             'INPLACE';
+INSERT_METHOD:                       'INSERT_METHOD';
+INSTALL:                             'INSTALL';
+INSTANCE:                            'INSTANCE';
+INSTANT:                             'INSTANT';
+INVISIBLE:                           'INVISIBLE';
+INVOKER:                             'INVOKER';
+IO:                                  'IO';
+IO_THREAD:                           'IO_THREAD';
+IPC:                                 'IPC';
+ISOLATION:                           'ISOLATION';
+ISSUER:                              'ISSUER';
+JSON:                                'JSON';
+KEY_BLOCK_SIZE:                      'KEY_BLOCK_SIZE';
+LANGUAGE:                            'LANGUAGE';
+LAST:                                'LAST';
+LEAVES:                              'LEAVES';
+LESS:                                'LESS';
+LEVEL:                               'LEVEL';
+LIST:                                'LIST';
+LOCAL:                               'LOCAL';
+LOGFILE:                             'LOGFILE';
+LOGS:                                'LOGS';
+MASTER:                              'MASTER';
+MASTER_AUTO_POSITION:                'MASTER_AUTO_POSITION';
+MASTER_CONNECT_RETRY:                'MASTER_CONNECT_RETRY';
+MASTER_DELAY:                        'MASTER_DELAY';
+MASTER_HEARTBEAT_PERIOD:             'MASTER_HEARTBEAT_PERIOD';
+MASTER_HOST:                         'MASTER_HOST';
+MASTER_LOG_FILE:                     'MASTER_LOG_FILE';
+MASTER_LOG_POS:                      'MASTER_LOG_POS';
+MASTER_PASSWORD:                     'MASTER_PASSWORD';
+MASTER_PORT:                         'MASTER_PORT';
+MASTER_RETRY_COUNT:                  'MASTER_RETRY_COUNT';
+MASTER_SSL:                          'MASTER_SSL';
+MASTER_SSL_CA:                       'MASTER_SSL_CA';
+MASTER_SSL_CAPATH:                   'MASTER_SSL_CAPATH';
+MASTER_SSL_CERT:                     'MASTER_SSL_CERT';
+MASTER_SSL_CIPHER:                   'MASTER_SSL_CIPHER';
+MASTER_SSL_CRL:                      'MASTER_SSL_CRL';
+MASTER_SSL_CRLPATH:                  'MASTER_SSL_CRLPATH';
+MASTER_SSL_KEY:                      'MASTER_SSL_KEY';
+MASTER_TLS_VERSION:                  'MASTER_TLS_VERSION';
+MASTER_USER:                         'MASTER_USER';
+MAX_CONNECTIONS_PER_HOUR:            'MAX_CONNECTIONS_PER_HOUR';
+MAX_QUERIES_PER_HOUR:                'MAX_QUERIES_PER_HOUR';
+MAX_ROWS:                            'MAX_ROWS';
+MAX_SIZE:                            'MAX_SIZE';
+MAX_UPDATES_PER_HOUR:                'MAX_UPDATES_PER_HOUR';
+MAX_USER_CONNECTIONS:                'MAX_USER_CONNECTIONS';
+MEDIUM:                              'MEDIUM';
+MEMBER:                              'MEMBER';
+MERGE:                               'MERGE';
+MESSAGE_TEXT:                        'MESSAGE_TEXT';
+MID:                                 'MID';
+MIGRATE:                             'MIGRATE';
+MIN_ROWS:                            'MIN_ROWS';
+MODE:                                'MODE';
+MODIFY:                              'MODIFY';
+MUTEX:                               'MUTEX';
+MYSQL:                               'MYSQL';
+MYSQL_ERRNO:                         'MYSQL_ERRNO';
+NAME:                                'NAME';
+NAMES:                               'NAMES';
+NCHAR:                               'NCHAR';
+NEVER:                               'NEVER';
+NEXT:                                'NEXT';
+NO:                                  'NO';
+NOCACHE:                             'NOCACHE';
+NOCOPY:                              'NOCOPY';
+NOCYCLE:                             'NOCYCLE';
+NOMAXVALUE:                          'NOMAXVALUE';
+NOMINVALUE:                          'NOMINVALUE';
+NOWAIT:                              'NOWAIT';
+NODEGROUP:                           'NODEGROUP';
+NONE:                                'NONE';
+ODBC:                                'ODBC';
+OFFLINE:                             'OFFLINE';
+OFFSET:                              'OFFSET';
+OF:                                  'OF';
+OJ:                                  'OJ';
+OLD_PASSWORD:                        'OLD_PASSWORD';
+ONE:                                 'ONE';
+ONLINE:                              'ONLINE';
+ONLY:                                'ONLY';
+OPEN:                                'OPEN';
+OPTIMIZER_COSTS:                     'OPTIMIZER_COSTS';
+OPTIONS:                             'OPTIONS';
+OWNER:                               'OWNER';
+PACK_KEYS:                           'PACK_KEYS';
+PAGE:                                'PAGE';
+PAGE_COMPRESSED:                     'PAGE_COMPRESSED';
+PAGE_COMPRESSION_LEVEL:              'PAGE_COMPRESSION_LEVEL';
+PARSER:                              'PARSER';
+PARTIAL:                             'PARTIAL';
+PARTITIONING:                        'PARTITIONING';
+PARTITIONS:                          'PARTITIONS';
+PASSWORD:                            'PASSWORD';
+PASSWORD_LOCK_TIME:                  'PASSWORD_LOCK_TIME';
+PHASE:                               'PHASE';
+PLUGIN:                              'PLUGIN';
+PLUGIN_DIR:                          'PLUGIN_DIR';
+PLUGINS:                             'PLUGINS';
+PORT:                                'PORT';
+PRECEDES:                            'PRECEDES';
+PRECEDING:                           'PRECEDING';
+PREPARE:                             'PREPARE';
+PRESERVE:                            'PRESERVE';
+PREV:                                'PREV';
+PROCESSLIST:                         'PROCESSLIST';
+PROFILE:                             'PROFILE';
+PROFILES:                            'PROFILES';
+PROXY:                               'PROXY';
+QUERY:                               'QUERY';
+QUICK:                               'QUICK';
+REBUILD:                             'REBUILD';
+RECOVER:                             'RECOVER';
+RECURSIVE:                           'RECURSIVE';
+REDO_BUFFER_SIZE:                    'REDO_BUFFER_SIZE';
+REDUNDANT:                           'REDUNDANT';
+RELAY:                               'RELAY';
+RELAY_LOG_FILE:                      'RELAY_LOG_FILE';
+RELAY_LOG_POS:                       'RELAY_LOG_POS';
+RELAYLOG:                            'RELAYLOG';
+REMOVE:                              'REMOVE';
+REORGANIZE:                          'REORGANIZE';
+REPAIR:                              'REPAIR';
+REPLICATE_DO_DB:                     'REPLICATE_DO_DB';
+REPLICATE_DO_TABLE:                  'REPLICATE_DO_TABLE';
+REPLICATE_IGNORE_DB:                 'REPLICATE_IGNORE_DB';
+REPLICATE_IGNORE_TABLE:              'REPLICATE_IGNORE_TABLE';
+REPLICATE_REWRITE_DB:                'REPLICATE_REWRITE_DB';
+REPLICATE_WILD_DO_TABLE:             'REPLICATE_WILD_DO_TABLE';
+REPLICATE_WILD_IGNORE_TABLE:         'REPLICATE_WILD_IGNORE_TABLE';
+REPLICATION:                         'REPLICATION';
+RESET:                               'RESET';
+RESTART:                             'RESTART';
+RESUME:                              'RESUME';
+RETURNED_SQLSTATE:                   'RETURNED_SQLSTATE';
+RETURNING:                           'RETURNING';
+RETURNS:                             'RETURNS';
+REUSE:                               'REUSE';
+ROLE:                                'ROLE';
+ROLLBACK:                            'ROLLBACK';
+ROLLUP:                              'ROLLUP';
+ROTATE:                              'ROTATE';
+ROW:                                 'ROW';
+ROWS:                                'ROWS';
+ROW_FORMAT:                          'ROW_FORMAT';
+RTREE:                               'RTREE';
+SAVEPOINT:                           'SAVEPOINT';
+SCHEDULE:                            'SCHEDULE';
+SECURITY:                            'SECURITY';
+SEQUENCE:                            'SEQUENCE';
+SERVER:                              'SERVER';
+SESSION:                             'SESSION';
+SHARE:                               'SHARE';
+SHARED:                              'SHARED';
+SIGNED:                              'SIGNED';
+SIMPLE:                              'SIMPLE';
+SLAVE:                               'SLAVE';
+SLOW:                                'SLOW';
+SNAPSHOT:                            'SNAPSHOT';
+SOCKET:                              'SOCKET';
+SOME:                                'SOME';
+SONAME:                              'SONAME';
+SOUNDS:                              'SOUNDS';
+SOURCE:                              'SOURCE';
+SQL_AFTER_GTIDS:                     'SQL_AFTER_GTIDS';
+SQL_AFTER_MTS_GAPS:                  'SQL_AFTER_MTS_GAPS';
+SQL_BEFORE_GTIDS:                    'SQL_BEFORE_GTIDS';
+SQL_BUFFER_RESULT:                   'SQL_BUFFER_RESULT';
+SQL_CACHE:                           'SQL_CACHE';
+SQL_NO_CACHE:                        'SQL_NO_CACHE';
+SQL_THREAD:                          'SQL_THREAD';
+START:                               'START';
+STARTS:                              'STARTS';
+STATS_AUTO_RECALC:                   'STATS_AUTO_RECALC';
+STATS_PERSISTENT:                    'STATS_PERSISTENT';
+STATS_SAMPLE_PAGES:                  'STATS_SAMPLE_PAGES';
+STATUS:                              'STATUS';
+STOP:                                'STOP';
+STORAGE:                             'STORAGE';
+STORED:                              'STORED';
+STRING:                              'STRING';
+SUBCLASS_ORIGIN:                     'SUBCLASS_ORIGIN';
+SUBJECT:                             'SUBJECT';
+SUBPARTITION:                        'SUBPARTITION';
+SUBPARTITIONS:                       'SUBPARTITIONS';
+SUSPEND:                             'SUSPEND';
+SWAPS:                               'SWAPS';
+SWITCHES:                            'SWITCHES';
+TABLE_NAME:                          'TABLE_NAME';
+TABLESPACE:                          'TABLESPACE';
+TABLE_TYPE:                          'TABLE_TYPE';
+TEMPORARY:                           'TEMPORARY';
+TEMPTABLE:                           'TEMPTABLE';
+THAN:                                'THAN';
+TRADITIONAL:                         'TRADITIONAL';
+TRANSACTION:                         'TRANSACTION';
+TRANSACTIONAL:                       'TRANSACTIONAL';
+TRIGGERS:                            'TRIGGERS';
+TRUNCATE:                            'TRUNCATE';
+UNBOUNDED:                           'UNBOUNDED';
+UNDEFINED:                           'UNDEFINED';
+UNDOFILE:                            'UNDOFILE';
+UNDO_BUFFER_SIZE:                    'UNDO_BUFFER_SIZE';
+UNINSTALL:                           'UNINSTALL';
+UNKNOWN:                             'UNKNOWN';
+UNTIL:                               'UNTIL';
+UPGRADE:                             'UPGRADE';
+USER:                                'USER';
+USE_FRM:                             'USE_FRM';
+USER_RESOURCES:                      'USER_RESOURCES';
+VALIDATION:                          'VALIDATION';
+VALUE:                               'VALUE';
+VARIABLES:                           'VARIABLES';
+VIEW:                                'VIEW';
+VIRTUAL:                             'VIRTUAL';
+VISIBLE:                             'VISIBLE';
+WAIT:                                'WAIT';
+WARNINGS:                            'WARNINGS';
+WINDOW:                              'WINDOW';
+WITHOUT:                             'WITHOUT';
+WORK:                                'WORK';
+WRAPPER:                             'WRAPPER';
+X509:                                'X509';
+XA:                                  'XA';
+XML:                                 'XML';
+YES:                                 'YES';
+
+// Date format Keywords
+
+EUR:                                 'EUR';
+USA:                                 'USA';
+JIS:                                 'JIS';
+ISO:                                 'ISO';
+INTERNAL:                            'INTERNAL';
+
+
+// Interval type Keywords
+
+QUARTER:                             'QUARTER';
+MONTH:                               'MONTH';
+DAY:                                 'DAY';
+HOUR:                                'HOUR';
+MINUTE:                              'MINUTE';
+WEEK:                                'WEEK';
+SECOND:                              'SECOND';
+MICROSECOND:                         'MICROSECOND';
+
+
+// PRIVILEGES
+
+ADMIN:                               'ADMIN';
+APPLICATION_PASSWORD_ADMIN:          'APPLICATION_PASSWORD_ADMIN';
+AUDIT_ADMIN:                         'AUDIT_ADMIN';
+BACKUP_ADMIN:                        'BACKUP_ADMIN';
+BINLOG_ADMIN:                        'BINLOG_ADMIN';
+BINLOG_ENCRYPTION_ADMIN:             'BINLOG_ENCRYPTION_ADMIN';
+CLONE_ADMIN:                         'CLONE_ADMIN';
+CONNECTION_ADMIN:                    'CONNECTION_ADMIN';
+ENCRYPTION_KEY_ADMIN:                'ENCRYPTION_KEY_ADMIN';
+EXECUTE:                             'EXECUTE';
+FILE:                                'FILE';
+FIREWALL_ADMIN:                      'FIREWALL_ADMIN';
+FIREWALL_USER:                       'FIREWALL_USER';
+FLUSH_OPTIMIZER_COSTS:               'FLUSH_OPTIMIZER_COSTS';
+FLUSH_STATUS:                        'FLUSH_STATUS';
+FLUSH_TABLES:                        'FLUSH_TABLES';
+FLUSH_USER_RESOURCES:                'FLUSH_USER_RESOURCES';
+GROUP_REPLICATION_ADMIN:             'GROUP_REPLICATION_ADMIN';
+INNODB_REDO_LOG_ARCHIVE:             'INNODB_REDO_LOG_ARCHIVE';
+INNODB_REDO_LOG_ENABLE:              'INNODB_REDO_LOG_ENABLE';
+INVOKE:                              'INVOKE';
+LAMBDA:                              'LAMBDA';
+NDB_STORED_USER:                     'NDB_STORED_USER';
+PASSWORDLESS_USER_ADMIN:             'PASSWORDLESS_USER_ADMIN';
+PERSIST_RO_VARIABLES_ADMIN:          'PERSIST_RO_VARIABLES_ADMIN';
+PRIVILEGES:                          'PRIVILEGES';
+PROCESS:                             'PROCESS';
+RELOAD:                              'RELOAD';
+REPLICATION_APPLIER:                 'REPLICATION_APPLIER';
+REPLICATION_SLAVE_ADMIN:             'REPLICATION_SLAVE_ADMIN';
+RESOURCE_GROUP_ADMIN:                'RESOURCE_GROUP_ADMIN';
+RESOURCE_GROUP_USER:                 'RESOURCE_GROUP_USER';
+ROLE_ADMIN:                          'ROLE_ADMIN';
+ROUTINE:                             'ROUTINE';
+S3:                                  'S3';
+SERVICE_CONNECTION_ADMIN:            'SERVICE_CONNECTION_ADMIN';
+SESSION_VARIABLES_ADMIN:             QUOTE_SYMB? 'SESSION_VARIABLES_ADMIN' QUOTE_SYMB?;
+SET_USER_ID:                         'SET_USER_ID';
+SHOW_ROUTINE:                        'SHOW_ROUTINE';
+SHUTDOWN:                            'SHUTDOWN';
+SUPER:                               'SUPER';
+SYSTEM_VARIABLES_ADMIN:              'SYSTEM_VARIABLES_ADMIN';
+TABLES:                              'TABLES';
+TABLE_ENCRYPTION_ADMIN:              'TABLE_ENCRYPTION_ADMIN';
+VERSION_TOKEN_ADMIN:                 'VERSION_TOKEN_ADMIN';
+XA_RECOVER_ADMIN:                    'XA_RECOVER_ADMIN';
+
+
+// Charsets
+
+ARMSCII8:                            'ARMSCII8';
+ASCII:                               'ASCII';
+BIG5:                                'BIG5';
+CP1250:                              'CP1250';
+CP1251:                              'CP1251';
+CP1256:                              'CP1256';
+CP1257:                              'CP1257';
+CP850:                               'CP850';
+CP852:                               'CP852';
+CP866:                               'CP866';
+CP932:                               'CP932';
+DEC8:                                'DEC8';
+EUCJPMS:                             'EUCJPMS';
+EUCKR:                               'EUCKR';
+GB18030:                             'GB18030';
+GB2312:                              'GB2312';
+GBK:                                 'GBK';
+GEOSTD8:                             'GEOSTD8';
+GREEK:                               'GREEK';
+HEBREW:                              'HEBREW';
+HP8:                                 'HP8';
+KEYBCS2:                             'KEYBCS2';
+KOI8R:                               'KOI8R';
+KOI8U:                               'KOI8U';
+LATIN1:                              'LATIN1';
+LATIN2:                              'LATIN2';
+LATIN5:                              'LATIN5';
+LATIN7:                              'LATIN7';
+MACCE:                               'MACCE';
+MACROMAN:                            'MACROMAN';
+SJIS:                                'SJIS';
+SWE7:                                'SWE7';
+TIS620:                              'TIS620';
+UCS2:                                'UCS2';
+UJIS:                                'UJIS';
+UTF16:                               'UTF16';
+UTF16LE:                             'UTF16LE';
+UTF32:                               'UTF32';
+UTF8:                                'UTF8';
+UTF8MB3:                             'UTF8MB3';
+UTF8MB4:                             'UTF8MB4';
+
+
+// DB Engines
+
+ARCHIVE:                             'ARCHIVE';
+BLACKHOLE:                           'BLACKHOLE';
+CSV:                                 'CSV';
+FEDERATED:                           'FEDERATED';
+INNODB:                              'INNODB';
+MEMORY:                              'MEMORY';
+MRG_MYISAM:                          'MRG_MYISAM';
+MYISAM:                              'MYISAM';
+NDB:                                 'NDB';
+NDBCLUSTER:                          'NDBCLUSTER';
+PERFORMANCE_SCHEMA:                  'PERFORMANCE_SCHEMA';
+TOKUDB:                              'TOKUDB';
+
+
+// Transaction Levels
+
+REPEATABLE:                          'REPEATABLE';
+COMMITTED:                           'COMMITTED';
+UNCOMMITTED:                         'UNCOMMITTED';
+SERIALIZABLE:                        'SERIALIZABLE';
+
+
+// Spatial data types
+
+GEOMETRYCOLLECTION:                  'GEOMETRYCOLLECTION';
+GEOMCOLLECTION:                      'GEOMCOLLECTION';
+GEOMETRY:                            'GEOMETRY';
+LINESTRING:                          'LINESTRING';
+MULTILINESTRING:                     'MULTILINESTRING';
+MULTIPOINT:                          'MULTIPOINT';
+MULTIPOLYGON:                        'MULTIPOLYGON';
+POINT:                               'POINT';
+POLYGON:                             'POLYGON';
+
+
+// Common function names
+
+ABS:                                 'ABS';
+ACOS:                                'ACOS';
+ADDDATE:                             'ADDDATE';
+ADDTIME:                             'ADDTIME';
+AES_DECRYPT:                         'AES_DECRYPT';
+AES_ENCRYPT:                         'AES_ENCRYPT';
+AREA:                                'AREA';
+ASBINARY:                            'ASBINARY';
+ASIN:                                'ASIN';
+ASTEXT:                              'ASTEXT';
+ASWKB:                               'ASWKB';
+ASWKT:                               'ASWKT';
+ASYMMETRIC_DECRYPT:                  'ASYMMETRIC_DECRYPT';
+ASYMMETRIC_DERIVE:                   'ASYMMETRIC_DERIVE';
+ASYMMETRIC_ENCRYPT:                  'ASYMMETRIC_ENCRYPT';
+ASYMMETRIC_SIGN:                     'ASYMMETRIC_SIGN';
+ASYMMETRIC_VERIFY:                   'ASYMMETRIC_VERIFY';
+ATAN:                                'ATAN';
+ATAN2:                               'ATAN2';
+BENCHMARK:                           'BENCHMARK';
+BIN:                                 'BIN';
+BIT_COUNT:                           'BIT_COUNT';
+BIT_LENGTH:                          'BIT_LENGTH';
+BUFFER:                              'BUFFER';
+CATALOG_NAME:                        'CATALOG_NAME';
+CEIL:                                'CEIL';
+CEILING:                             'CEILING';
+CENTROID:                            'CENTROID';
+CHARACTER_LENGTH:                    'CHARACTER_LENGTH';
+CHARSET:                             'CHARSET';
+CHAR_LENGTH:                         'CHAR_LENGTH';
+COERCIBILITY:                        'COERCIBILITY';
+COLLATION:                           'COLLATION';
+COMPRESS:                            'COMPRESS';
+CONCAT:                              'CONCAT';
+CONCAT_WS:                           'CONCAT_WS';
+CONNECTION_ID:                       'CONNECTION_ID';
+CONV:                                'CONV';
+CONVERT_TZ:                          'CONVERT_TZ';
+COS:                                 'COS';
+COT:                                 'COT';
+CRC32:                               'CRC32';
+CREATE_ASYMMETRIC_PRIV_KEY:          'CREATE_ASYMMETRIC_PRIV_KEY';
+CREATE_ASYMMETRIC_PUB_KEY:           'CREATE_ASYMMETRIC_PUB_KEY';
+CREATE_DH_PARAMETERS:                'CREATE_DH_PARAMETERS';
+CREATE_DIGEST:                       'CREATE_DIGEST';
+CROSSES:                             'CROSSES';
+DATEDIFF:                            'DATEDIFF';
+DATE_FORMAT:                         'DATE_FORMAT';
+DAYNAME:                             'DAYNAME';
+DAYOFMONTH:                          'DAYOFMONTH';
+DAYOFWEEK:                           'DAYOFWEEK';
+DAYOFYEAR:                           'DAYOFYEAR';
+DECODE:                              'DECODE';
+DEGREES:                             'DEGREES';
+DES_DECRYPT:                         'DES_DECRYPT';
+DES_ENCRYPT:                         'DES_ENCRYPT';
+DIMENSION:                           'DIMENSION';
+DISJOINT:                            'DISJOINT';
+ELT:                                 'ELT';
+ENCODE:                              'ENCODE';
+ENCRYPT:                             'ENCRYPT';
+ENDPOINT:                            'ENDPOINT';
+ENGINE_ATTRIBUTE:                    'ENGINE_ATTRIBUTE';
+ENVELOPE:                            'ENVELOPE';
+EQUALS:                              'EQUALS';
+EXP:                                 'EXP';
+EXPORT_SET:                          'EXPORT_SET';
+EXTERIORRING:                        'EXTERIORRING';
+EXTRACTVALUE:                        'EXTRACTVALUE';
+FIELD:                               'FIELD';
+FIND_IN_SET:                         'FIND_IN_SET';
+FLOOR:                               'FLOOR';
+FORMAT:                              'FORMAT';
+FOUND_ROWS:                          'FOUND_ROWS';
+FROM_BASE64:                         'FROM_BASE64';
+FROM_DAYS:                           'FROM_DAYS';
+FROM_UNIXTIME:                       'FROM_UNIXTIME';
+GEOMCOLLFROMTEXT:                    'GEOMCOLLFROMTEXT';
+GEOMCOLLFROMWKB:                     'GEOMCOLLFROMWKB';
+GEOMETRYCOLLECTIONFROMTEXT:          'GEOMETRYCOLLECTIONFROMTEXT';
+GEOMETRYCOLLECTIONFROMWKB:           'GEOMETRYCOLLECTIONFROMWKB';
+GEOMETRYFROMTEXT:                    'GEOMETRYFROMTEXT';
+GEOMETRYFROMWKB:                     'GEOMETRYFROMWKB';
+GEOMETRYN:                           'GEOMETRYN';
+GEOMETRYTYPE:                        'GEOMETRYTYPE';
+GEOMFROMTEXT:                        'GEOMFROMTEXT';
+GEOMFROMWKB:                         'GEOMFROMWKB';
+GET_FORMAT:                          'GET_FORMAT';
+GET_LOCK:                            'GET_LOCK';
+GLENGTH:                             'GLENGTH';
+GREATEST:                            'GREATEST';
+GTID_SUBSET:                         'GTID_SUBSET';
+GTID_SUBTRACT:                       'GTID_SUBTRACT';
+HEX:                                 'HEX';
+IFNULL:                              'IFNULL';
+INET6_ATON:                          'INET6_ATON';
+INET6_NTOA:                          'INET6_NTOA';
+INET_ATON:                           'INET_ATON';
+INET_NTOA:                           'INET_NTOA';
+INSTR:                               'INSTR';
+INTERIORRINGN:                       'INTERIORRINGN';
+INTERSECTS:                          'INTERSECTS';
+ISCLOSED:                            'ISCLOSED';
+ISEMPTY:                             'ISEMPTY';
+ISNULL:                              'ISNULL';
+ISSIMPLE:                            'ISSIMPLE';
+IS_FREE_LOCK:                        'IS_FREE_LOCK';
+IS_IPV4:                             'IS_IPV4';
+IS_IPV4_COMPAT:                      'IS_IPV4_COMPAT';
+IS_IPV4_MAPPED:                      'IS_IPV4_MAPPED';
+IS_IPV6:                             'IS_IPV6';
+IS_USED_LOCK:                        'IS_USED_LOCK';
+LAST_INSERT_ID:                      'LAST_INSERT_ID';
+LCASE:                               'LCASE';
+LEAST:                               'LEAST';
+LENGTH:                              'LENGTH';
+LINEFROMTEXT:                        'LINEFROMTEXT';
+LINEFROMWKB:                         'LINEFROMWKB';
+LINESTRINGFROMTEXT:                  'LINESTRINGFROMTEXT';
+LINESTRINGFROMWKB:                   'LINESTRINGFROMWKB';
+LN:                                  'LN';
+LOAD_FILE:                           'LOAD_FILE';
+LOCATE:                              'LOCATE';
+LOG:                                 'LOG';
+LOG10:                               'LOG10';
+LOG2:                                'LOG2';
+LOWER:                               'LOWER';
+LPAD:                                'LPAD';
+LTRIM:                               'LTRIM';
+MAKEDATE:                            'MAKEDATE';
+MAKETIME:                            'MAKETIME';
+MAKE_SET:                            'MAKE_SET';
+MASTER_POS_WAIT:                     'MASTER_POS_WAIT';
+MBRCONTAINS:                         'MBRCONTAINS';
+MBRDISJOINT:                         'MBRDISJOINT';
+MBREQUAL:                            'MBREQUAL';
+MBRINTERSECTS:                       'MBRINTERSECTS';
+MBROVERLAPS:                         'MBROVERLAPS';
+MBRTOUCHES:                          'MBRTOUCHES';
+MBRWITHIN:                           'MBRWITHIN';
+MD5:                                 'MD5';
+MLINEFROMTEXT:                       'MLINEFROMTEXT';
+MLINEFROMWKB:                        'MLINEFROMWKB';
+MONTHNAME:                           'MONTHNAME';
+MPOINTFROMTEXT:                      'MPOINTFROMTEXT';
+MPOINTFROMWKB:                       'MPOINTFROMWKB';
+MPOLYFROMTEXT:                       'MPOLYFROMTEXT';
+MPOLYFROMWKB:                        'MPOLYFROMWKB';
+MULTILINESTRINGFROMTEXT:             'MULTILINESTRINGFROMTEXT';
+MULTILINESTRINGFROMWKB:              'MULTILINESTRINGFROMWKB';
+MULTIPOINTFROMTEXT:                  'MULTIPOINTFROMTEXT';
+MULTIPOINTFROMWKB:                   'MULTIPOINTFROMWKB';
+MULTIPOLYGONFROMTEXT:                'MULTIPOLYGONFROMTEXT';
+MULTIPOLYGONFROMWKB:                 'MULTIPOLYGONFROMWKB';
+NAME_CONST:                          'NAME_CONST';
+NULLIF:                              'NULLIF';
+NUMGEOMETRIES:                       'NUMGEOMETRIES';
+NUMINTERIORRINGS:                    'NUMINTERIORRINGS';
+NUMPOINTS:                           'NUMPOINTS';
+OCT:                                 'OCT';
+OCTET_LENGTH:                        'OCTET_LENGTH';
+ORD:                                 'ORD';
+OVERLAPS:                            'OVERLAPS';
+PERIOD_ADD:                          'PERIOD_ADD';
+PERIOD_DIFF:                         'PERIOD_DIFF';
+PI:                                  'PI';
+POINTFROMTEXT:                       'POINTFROMTEXT';
+POINTFROMWKB:                        'POINTFROMWKB';
+POINTN:                              'POINTN';
+POLYFROMTEXT:                        'POLYFROMTEXT';
+POLYFROMWKB:                         'POLYFROMWKB';
+POLYGONFROMTEXT:                     'POLYGONFROMTEXT';
+POLYGONFROMWKB:                      'POLYGONFROMWKB';
+POW:                                 'POW';
+POWER:                               'POWER';
+QUOTE:                               'QUOTE';
+RADIANS:                             'RADIANS';
+RAND:                                'RAND';
+RANDOM_BYTES:                        'RANDOM_BYTES';
+RELEASE_LOCK:                        'RELEASE_LOCK';
+REVERSE:                             'REVERSE';
+ROUND:                               'ROUND';
+ROW_COUNT:                           'ROW_COUNT';
+RPAD:                                'RPAD';
+RTRIM:                               'RTRIM';
+SEC_TO_TIME:                         'SEC_TO_TIME';
+SECONDARY_ENGINE_ATTRIBUTE:          'SECONDARY_ENGINE_ATTRIBUTE';
+SESSION_USER:                        'SESSION_USER';
+SHA:                                 'SHA';
+SHA1:                                'SHA1';
+SHA2:                                'SHA2';
+SCHEMA_NAME:                         'SCHEMA_NAME';
+SIGN:                                'SIGN';
+SIN:                                 'SIN';
+SLEEP:                               'SLEEP';
+SOUNDEX:                             'SOUNDEX';
+SQL_THREAD_WAIT_AFTER_GTIDS:         'SQL_THREAD_WAIT_AFTER_GTIDS';
+SQRT:                                'SQRT';
+SRID:                                'SRID';
+STARTPOINT:                          'STARTPOINT';
+STRCMP:                              'STRCMP';
+STR_TO_DATE:                         'STR_TO_DATE';
+ST_AREA:                             'ST_AREA';
+ST_ASBINARY:                         'ST_ASBINARY';
+ST_ASTEXT:                           'ST_ASTEXT';
+ST_ASWKB:                            'ST_ASWKB';
+ST_ASWKT:                            'ST_ASWKT';
+ST_BUFFER:                           'ST_BUFFER';
+ST_CENTROID:                         'ST_CENTROID';
+ST_CONTAINS:                         'ST_CONTAINS';
+ST_CROSSES:                          'ST_CROSSES';
+ST_DIFFERENCE:                       'ST_DIFFERENCE';
+ST_DIMENSION:                        'ST_DIMENSION';
+ST_DISJOINT:                         'ST_DISJOINT';
+ST_DISTANCE:                         'ST_DISTANCE';
+ST_ENDPOINT:                         'ST_ENDPOINT';
+ST_ENVELOPE:                         'ST_ENVELOPE';
+ST_EQUALS:                           'ST_EQUALS';
+ST_EXTERIORRING:                     'ST_EXTERIORRING';
+ST_GEOMCOLLFROMTEXT:                 'ST_GEOMCOLLFROMTEXT';
+ST_GEOMCOLLFROMTXT:                  'ST_GEOMCOLLFROMTXT';
+ST_GEOMCOLLFROMWKB:                  'ST_GEOMCOLLFROMWKB';
+ST_GEOMETRYCOLLECTIONFROMTEXT:       'ST_GEOMETRYCOLLECTIONFROMTEXT';
+ST_GEOMETRYCOLLECTIONFROMWKB:        'ST_GEOMETRYCOLLECTIONFROMWKB';
+ST_GEOMETRYFROMTEXT:                 'ST_GEOMETRYFROMTEXT';
+ST_GEOMETRYFROMWKB:                  'ST_GEOMETRYFROMWKB';
+ST_GEOMETRYN:                        'ST_GEOMETRYN';
+ST_GEOMETRYTYPE:                     'ST_GEOMETRYTYPE';
+ST_GEOMFROMTEXT:                     'ST_GEOMFROMTEXT';
+ST_GEOMFROMWKB:                      'ST_GEOMFROMWKB';
+ST_INTERIORRINGN:                    'ST_INTERIORRINGN';
+ST_INTERSECTION:                     'ST_INTERSECTION';
+ST_INTERSECTS:                       'ST_INTERSECTS';
+ST_ISCLOSED:                         'ST_ISCLOSED';
+ST_ISEMPTY:                          'ST_ISEMPTY';
+ST_ISSIMPLE:                         'ST_ISSIMPLE';
+ST_LINEFROMTEXT:                     'ST_LINEFROMTEXT';
+ST_LINEFROMWKB:                      'ST_LINEFROMWKB';
+ST_LINESTRINGFROMTEXT:               'ST_LINESTRINGFROMTEXT';
+ST_LINESTRINGFROMWKB:                'ST_LINESTRINGFROMWKB';
+ST_NUMGEOMETRIES:                    'ST_NUMGEOMETRIES';
+ST_NUMINTERIORRING:                  'ST_NUMINTERIORRING';
+ST_NUMINTERIORRINGS:                 'ST_NUMINTERIORRINGS';
+ST_NUMPOINTS:                        'ST_NUMPOINTS';
+ST_OVERLAPS:                         'ST_OVERLAPS';
+ST_POINTFROMTEXT:                    'ST_POINTFROMTEXT';
+ST_POINTFROMWKB:                     'ST_POINTFROMWKB';
+ST_POINTN:                           'ST_POINTN';
+ST_POLYFROMTEXT:                     'ST_POLYFROMTEXT';
+ST_POLYFROMWKB:                      'ST_POLYFROMWKB';
+ST_POLYGONFROMTEXT:                  'ST_POLYGONFROMTEXT';
+ST_POLYGONFROMWKB:                   'ST_POLYGONFROMWKB';
+ST_SRID:                             'ST_SRID';
+ST_STARTPOINT:                       'ST_STARTPOINT';
+ST_SYMDIFFERENCE:                    'ST_SYMDIFFERENCE';
+ST_TOUCHES:                          'ST_TOUCHES';
+ST_UNION:                            'ST_UNION';
+ST_WITHIN:                           'ST_WITHIN';
+ST_X:                                'ST_X';
+ST_Y:                                'ST_Y';
+SUBDATE:                             'SUBDATE';
+SUBSTRING_INDEX:                     'SUBSTRING_INDEX';
+SUBTIME:                             'SUBTIME';
+SYSTEM_USER:                         'SYSTEM_USER';
+TAN:                                 'TAN';
+TIMEDIFF:                            'TIMEDIFF';
+TIMESTAMPADD:                        'TIMESTAMPADD';
+TIMESTAMPDIFF:                       'TIMESTAMPDIFF';
+TIME_FORMAT:                         'TIME_FORMAT';
+TIME_TO_SEC:                         'TIME_TO_SEC';
+TOUCHES:                             'TOUCHES';
+TO_BASE64:                           'TO_BASE64';
+TO_DAYS:                             'TO_DAYS';
+TO_SECONDS:                          'TO_SECONDS';
+UCASE:                               'UCASE';
+UNCOMPRESS:                          'UNCOMPRESS';
+UNCOMPRESSED_LENGTH:                 'UNCOMPRESSED_LENGTH';
+UNHEX:                               'UNHEX';
+UNIX_TIMESTAMP:                      'UNIX_TIMESTAMP';
+UPDATEXML:                           'UPDATEXML';
+UPPER:                               'UPPER';
+UUID:                                'UUID';
+UUID_SHORT:                          'UUID_SHORT';
+VALIDATE_PASSWORD_STRENGTH:          'VALIDATE_PASSWORD_STRENGTH';
+VERSION:                             'VERSION';
+WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS:   'WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS';
+WEEKDAY:                             'WEEKDAY';
+WEEKOFYEAR:                          'WEEKOFYEAR';
+WEIGHT_STRING:                       'WEIGHT_STRING';
+WITHIN:                              'WITHIN';
+YEARWEEK:                            'YEARWEEK';
+Y_FUNCTION:                          'Y';
+X_FUNCTION:                          'X';
+
+
+
+
+// Operators
+// Operators. Assigns
+
+VAR_ASSIGN:                          ':=';
+PLUS_ASSIGN:                         '+=';
+MINUS_ASSIGN:                        '-=';
+MULT_ASSIGN:                         '*=';
+DIV_ASSIGN:                          '/=';
+MOD_ASSIGN:                          '%=';
+AND_ASSIGN:                          '&=';
+XOR_ASSIGN:                          '^=';
+OR_ASSIGN:                           '|=';
+
+
+// Operators. Arithmetics
+
+STAR:                                '*';
+DIVIDE:                              '/';
+MODULE:                              '%';
+PLUS:                                '+';
+MINUS:                               '-';
+DIV:                                 'DIV';
+MOD:                                 'MOD';
+
+
+// Operators. Comparation
+
+EQUAL_SYMBOL:                        '=';
+GREATER_SYMBOL:                      '>';
+LESS_SYMBOL:                         '<';
+EXCLAMATION_SYMBOL:                  '!';
+
+
+// Operators. Bit
+
+BIT_NOT_OP:                          '~';
+BIT_OR_OP:                           '|';
+BIT_AND_OP:                          '&';
+BIT_XOR_OP:                          '^';
+
+
+// Constructors symbols
+
+DOT:                                 '.';
+LR_BRACKET:                          '(';
+RR_BRACKET:                          ')';
+COMMA:                               ',';
+SEMI:                                ';';
+AT_SIGN:                             '@';
+ZERO_DECIMAL:                        '0';
+ONE_DECIMAL:                         '1';
+TWO_DECIMAL:                         '2';
+SINGLE_QUOTE_SYMB:                   '\'';
+DOUBLE_QUOTE_SYMB:                   '"';
+REVERSE_QUOTE_SYMB:                  '`';
+COLON_SYMB:                          ':';
+
+fragment QUOTE_SYMB
+    : SINGLE_QUOTE_SYMB | DOUBLE_QUOTE_SYMB | REVERSE_QUOTE_SYMB
+    ;
+
+
+
+// Charsets
+
+CHARSET_REVERSE_QOUTE_STRING:        '`' CHARSET_NAME '`';
+
+
+
+// File's sizes
+
+
+FILESIZE_LITERAL:                    DEC_DIGIT+ ('K'|'M'|'G'|'T');
+
+
+
+// Literal Primitives
+
+
+START_NATIONAL_STRING_LITERAL:       'N' SQUOTA_STRING;
+STRING_LITERAL:                      DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;
+DECIMAL_LITERAL:                     DEC_DIGIT+;
+HEXADECIMAL_LITERAL:                 'X' '\'' (HEX_DIGIT HEX_DIGIT)+ '\''
+                                     | '0X' HEX_DIGIT+;
+
+REAL_LITERAL:                        (DEC_DIGIT+)? '.' DEC_DIGIT+
+                                     | DEC_DIGIT+ '.' EXPONENT_NUM_PART
+                                     | (DEC_DIGIT+)? '.' (DEC_DIGIT+ EXPONENT_NUM_PART)
+                                     | DEC_DIGIT+ EXPONENT_NUM_PART;
+NULL_SPEC_LITERAL:                   '\\' 'N';
+BIT_STRING:                          BIT_STRING_L;
+STRING_CHARSET_NAME:                 '_' CHARSET_NAME;
+
+
+
+
+// Hack for dotID
+// Prevent recognize string:         .123somelatin AS ((.123), FLOAT_LITERAL), ((somelatin), ID)
+//  it must recoginze:               .123somelatin AS ((.), DOT), (123somelatin, ID)
+
+DOT_ID:                              '.' ID_LITERAL;
+
+
+
+// Identifiers
+
+ID:                                  ID_LITERAL;
+// DOUBLE_QUOTE_ID:                  '"' ~'"'+ '"';
+REVERSE_QUOTE_ID:                    '`' ~'`'+ '`';
+STRING_USER_NAME:                    (
+                                       SQUOTA_STRING | DQUOTA_STRING
+                                       | BQUOTA_STRING | ID_LITERAL
+                                     ) '@'
+                                     (
+                                       SQUOTA_STRING | DQUOTA_STRING
+                                       | BQUOTA_STRING | ID_LITERAL
+                                       | IP_ADDRESS
+                                     );
+IP_ADDRESS:                          (
+                                       [0-9]+ '.' [0-9.]+
+                                       | [0-9A-F:]+ ':' [0-9A-F:]+
+                                     );
+LOCAL_ID:                               '@'
+                                     (
+                                        [A-Z0-9._$]+
+                                        | SQUOTA_STRING
+                                        | DQUOTA_STRING
+                                        | BQUOTA_STRING
+                                    );
+GLOBAL_ID:                              '@' '@'
+                                    (
+                                        [A-Z0-9._$]+
+                                        | BQUOTA_STRING
+                                    );
+
+
+// Fragments for Literal primitives
+
+fragment CHARSET_NAME:               ARMSCII8 | ASCII | BIG5 | BINARY | CP1250
+                                     | CP1251 | CP1256 | CP1257 | CP850
+                                     | CP852 | CP866 | CP932 | DEC8 | EUCJPMS
+                                     | EUCKR | GB2312 | GBK | GEOSTD8 | GREEK
+                                     | HEBREW | HP8 | KEYBCS2 | KOI8R | KOI8U
+                                     | LATIN1 | LATIN2 | LATIN5 | LATIN7
+                                     | MACCE | MACROMAN | SJIS | SWE7 | TIS620
+                                     | UCS2 | UJIS | UTF16 | UTF16LE | UTF32
+                                     | UTF8 | UTF8MB3 | UTF8MB4;
+
+fragment EXPONENT_NUM_PART:          'E' [-+]? DEC_DIGIT+;
+fragment ID_LITERAL:                 [A-Z_$0-9\u0080-\uFFFF]*?[A-Z_$\u0080-\uFFFF]+?[A-Z_$0-9\u0080-\uFFFF]*;
+fragment DQUOTA_STRING:              '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
+fragment SQUOTA_STRING:              '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
+fragment BQUOTA_STRING:              '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';
+fragment HEX_DIGIT:                  [0-9A-F];
+fragment DEC_DIGIT:                  [0-9];
+fragment BIT_STRING_L:               'B' '\'' [01]+ '\'';
+
+
+
+// Last tokens must generate Errors
+
+ERROR_RECONGNIGION:                  .    -> channel(ERRORCHANNEL);

--- a/src/main/antlr4/io/dbsink/connector/sink/ddl/parser/mysql/MySqlParser.g4
+++ b/src/main/antlr4/io/dbsink/connector/sink/ddl/parser/mysql/MySqlParser.g4
@@ -1,0 +1,2843 @@
+/*
+MySQL (Positive Technologies) grammar
+The MIT License (MIT).
+Copyright (c) 2015-2017, Ivan Kochurkin (kvanttt@gmail.com), Positive Technologies.
+Copyright (c) 2017, Ivan Khudyashev (IHudyashov@ptsecurity.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+parser grammar MySqlParser;
+
+options { tokenVocab=MySqlLexer; }
+
+
+// Top Level Description
+
+root
+    : sqlStatements? (MINUS MINUS)? EOF
+    ;
+
+sqlStatements
+    : (sqlStatement (MINUS MINUS)? SEMI? | emptyStatement_)*
+    (sqlStatement ((MINUS MINUS)? SEMI)? | emptyStatement_)
+    ;
+
+sqlStatement
+    : ddlStatement | dmlStatement | transactionStatement
+    | replicationStatement | preparedStatement
+    | administrationStatement | utilityStatement
+    ;
+
+emptyStatement_
+    : SEMI
+    ;
+
+ddlStatement
+    : createDatabase | createEvent | createIndex
+    | createLogfileGroup | createProcedure | createFunction
+    | createServer | createTable | createTablespaceInnodb
+    | createTablespaceNdb | createTrigger | createView | createRole
+    | alterDatabase | alterEvent | alterFunction
+    | alterInstance | alterLogfileGroup | alterProcedure
+    | alterServer | alterTable | alterTablespace | alterView
+    | dropDatabase | dropEvent | dropIndex
+    | dropLogfileGroup | dropProcedure | dropFunction
+    | dropServer | dropTable | dropTablespace
+    | dropTrigger | dropView | dropRole | setRole
+    | renameTable | truncateTable
+    ;
+
+dmlStatement
+    : selectStatement | insertStatement | updateStatement
+    | deleteStatement | replaceStatement | callStatement
+    | loadDataStatement | loadXmlStatement | doStatement
+    | handlerStatement | valuesStatement | withStatement
+    ;
+
+transactionStatement
+    : startTransaction
+    | beginWork | commitWork | rollbackWork
+    | savepointStatement | rollbackStatement
+    | releaseStatement | lockTables | unlockTables
+    ;
+
+replicationStatement
+    : changeMaster | changeReplicationFilter | purgeBinaryLogs
+    | resetMaster | resetSlave | startSlave | stopSlave
+    | startGroupReplication | stopGroupReplication
+    | xaStartTransaction | xaEndTransaction | xaPrepareStatement
+    | xaCommitWork | xaRollbackWork | xaRecoverWork
+    ;
+
+preparedStatement
+    : prepareStatement | executeStatement | deallocatePrepare
+    ;
+
+// remark: NOT INCLUDED IN sqlStatement, but include in body
+//  of routine's statements
+compoundStatement
+    : blockStatement
+    | caseStatement | ifStatement | leaveStatement
+    | loopStatement | repeatStatement | whileStatement
+    | iterateStatement | returnStatement | cursorStatement
+    ;
+
+administrationStatement
+    : alterUser | createUser | dropUser | grantStatement
+    | grantProxy | renameUser | revokeStatement
+    | revokeProxy | analyzeTable | checkTable
+    | checksumTable | optimizeTable | repairTable
+    | createUdfunction | installPlugin | uninstallPlugin
+    | setStatement | showStatement | binlogStatement
+    | cacheIndexStatement | flushStatement | killStatement
+    | loadIndexIntoCache | resetStatement
+    | shutdownStatement
+    ;
+
+utilityStatement
+    : simpleDescribeStatement | fullDescribeStatement
+    | helpStatement | useStatement | signalStatement
+    | resignalStatement | diagnosticsStatement
+    ;
+
+
+// Data Definition Language
+
+//    Create statements
+
+createDatabase
+    : CREATE dbFormat=(DATABASE | SCHEMA)
+      ifNotExists? uid createDatabaseOption*
+    ;
+
+createEvent
+    : CREATE ownerStatement? EVENT ifNotExists? fullId
+      ON SCHEDULE scheduleExpression
+      (ON COMPLETION NOT? PRESERVE)? enableType?
+      (COMMENT STRING_LITERAL)?
+      DO routineBody
+    ;
+
+createIndex
+    : CREATE
+      intimeAction=(ONLINE | OFFLINE)?
+      indexCategory=(UNIQUE | FULLTEXT | SPATIAL)? INDEX
+      uid indexType?
+      ON tableName indexColumnNames
+      indexOption*
+      (
+        ALGORITHM EQUAL_SYMBOL? algType=(DEFAULT | INPLACE | COPY)
+        | LOCK EQUAL_SYMBOL? lockType=(DEFAULT | NONE | SHARED | EXCLUSIVE)
+      )*
+    ;
+
+createLogfileGroup
+    : CREATE LOGFILE GROUP uid
+      ADD UNDOFILE undoFile=STRING_LITERAL
+      (INITIAL_SIZE '='? initSize=fileSizeLiteral)?
+      (UNDO_BUFFER_SIZE '='? undoSize=fileSizeLiteral)?
+      (REDO_BUFFER_SIZE '='? redoSize=fileSizeLiteral)?
+      (NODEGROUP '='? uid)?
+      WAIT?
+      (COMMENT '='? comment=STRING_LITERAL)?
+      ENGINE '='? engineName
+    ;
+
+createProcedure
+    : CREATE ownerStatement?
+      PROCEDURE fullId
+      '(' procedureParameter? (',' procedureParameter)* ')'
+      routineOption*
+      routineBody
+    ;
+
+createFunction
+    : CREATE ownerStatement? AGGREGATE?
+      FUNCTION ifNotExists? fullId
+      '(' functionParameter? (',' functionParameter)* ')'
+      RETURNS dataType
+      routineOption*
+      (routineBody | returnStatement)
+    ;
+
+createRole
+    : CREATE ROLE ifNotExists? roleName (',' roleName)*
+    ;
+
+createServer
+    : CREATE SERVER uid
+    FOREIGN DATA WRAPPER wrapperName=(MYSQL | STRING_LITERAL)
+    OPTIONS '(' serverOption (',' serverOption)* ')'
+    ;
+
+createTable
+    : CREATE TEMPORARY? TABLE ifNotExists?
+       tableName
+       (
+         LIKE tableName
+         | '(' LIKE parenthesisTable=tableName ')'
+       )                                                            #copyCreateTable
+    | CREATE TEMPORARY? TABLE ifNotExists?
+       tableName createDefinitions?
+       ( tableOption (','? tableOption)* )?
+       partitionDefinitions? keyViolate=(IGNORE | REPLACE)?
+       AS? selectStatement                                          #queryCreateTable
+    | CREATE TEMPORARY? TABLE ifNotExists?
+       tableName createDefinitions
+       ( tableOption (','? tableOption)* )?
+       partitionDefinitions?                                        #columnCreateTable
+    ;
+
+createTablespaceInnodb
+    : CREATE TABLESPACE uid
+      ADD DATAFILE datafile=STRING_LITERAL
+      (FILE_BLOCK_SIZE '=' fileBlockSize=fileSizeLiteral)?
+      (ENGINE '='? engineName)?
+    ;
+
+createTablespaceNdb
+    : CREATE TABLESPACE uid
+      ADD DATAFILE datafile=STRING_LITERAL
+      USE LOGFILE GROUP uid
+      (EXTENT_SIZE '='? extentSize=fileSizeLiteral)?
+      (INITIAL_SIZE '='? initialSize=fileSizeLiteral)?
+      (AUTOEXTEND_SIZE '='? autoextendSize=fileSizeLiteral)?
+      (MAX_SIZE '='? maxSize=fileSizeLiteral)?
+      (NODEGROUP '='? uid)?
+      WAIT?
+      (COMMENT '='? comment=STRING_LITERAL)?
+      ENGINE '='? engineName
+    ;
+
+createTrigger
+    : CREATE ownerStatement?
+      TRIGGER thisTrigger=fullId
+      triggerTime=(BEFORE | AFTER)
+      triggerEvent=(INSERT | UPDATE | DELETE)
+      ON tableName FOR EACH ROW
+      (triggerPlace=(FOLLOWS | PRECEDES) otherTrigger=fullId)?
+      routineBody
+    ;
+
+withClause
+    : WITH RECURSIVE? commonTableExpressions
+    ;
+
+commonTableExpressions
+    : cteName ('(' cteColumnName (',' cteColumnName)* ')')?  AS '(' dmlStatement ')'
+      (',' commonTableExpressions)?
+    ;
+
+cteName
+    : uid
+    ;
+
+cteColumnName
+    : uid
+    ;
+
+createView
+    : CREATE orReplace?
+      (
+        ALGORITHM '=' algType=(UNDEFINED | MERGE | TEMPTABLE)
+      )?
+      ownerStatement?
+      (SQL SECURITY secContext=(DEFINER | INVOKER))?
+      VIEW fullId ('(' uidList ')')? AS
+      (
+        '(' withClause? selectStatement ')'
+        |
+        withClause? selectStatement (WITH checkOption=(CASCADED | LOCAL)? CHECK OPTION)?
+      )
+    ;
+
+
+// details
+
+createDatabaseOption
+    : DEFAULT? charSet '='? (charsetName | DEFAULT)
+    | DEFAULT? COLLATE '='? collationName
+    | DEFAULT? ENCRYPTION '='? STRING_LITERAL
+    | READ ONLY '='? (DEFAULT | ZERO_DECIMAL | ONE_DECIMAL)
+    ;
+
+charSet
+    : CHARACTER SET
+    | CHARSET
+    | CHAR SET
+    ;
+
+ownerStatement
+    : DEFINER '=' (userName | CURRENT_USER ( '(' ')')?)
+    ;
+
+scheduleExpression
+    : AT timestampValue intervalExpr*                               #preciseSchedule
+    | EVERY (decimalLiteral | expression) intervalType
+        (
+          STARTS startTimestamp=timestampValue
+          (startIntervals+=intervalExpr)*
+        )?
+        (
+          ENDS endTimestamp=timestampValue
+          (endIntervals+=intervalExpr)*
+        )?                                                          #intervalSchedule
+    ;
+
+timestampValue
+    : CURRENT_TIMESTAMP
+    | stringLiteral
+    | decimalLiteral
+    | expression
+    ;
+
+intervalExpr
+    : '+' INTERVAL (decimalLiteral | expression) intervalType
+    ;
+
+intervalType
+    : intervalTypeBase
+    | YEAR | YEAR_MONTH | DAY_HOUR | DAY_MINUTE
+    | DAY_SECOND | HOUR_MINUTE | HOUR_SECOND | MINUTE_SECOND
+    | SECOND_MICROSECOND | MINUTE_MICROSECOND
+    | HOUR_MICROSECOND | DAY_MICROSECOND
+    ;
+
+enableType
+    : ENABLE | DISABLE | DISABLE ON SLAVE
+    ;
+
+indexType
+    : USING (BTREE | HASH)
+    ;
+
+indexOption
+    : KEY_BLOCK_SIZE EQUAL_SYMBOL? fileSizeLiteral
+    | indexType
+    | WITH PARSER uid
+    | COMMENT STRING_LITERAL
+    | (VISIBLE | INVISIBLE)
+    | ENGINE_ATTRIBUTE EQUAL_SYMBOL? STRING_LITERAL
+    | SECONDARY_ENGINE_ATTRIBUTE EQUAL_SYMBOL? STRING_LITERAL
+    ;
+
+procedureParameter
+    : direction=(IN | OUT | INOUT)? uid dataType
+    ;
+
+functionParameter
+    : uid dataType
+    ;
+
+routineOption
+    : COMMENT STRING_LITERAL                                        #routineComment
+    | LANGUAGE SQL                                                  #routineLanguage
+    | NOT? DETERMINISTIC                                            #routineBehavior
+    | (
+        CONTAINS SQL | NO SQL | READS SQL DATA
+        | MODIFIES SQL DATA
+      )                                                             #routineData
+    | SQL SECURITY context=(DEFINER | INVOKER)                      #routineSecurity
+    ;
+
+serverOption
+    : HOST STRING_LITERAL
+    | DATABASE STRING_LITERAL
+    | USER STRING_LITERAL
+    | PASSWORD STRING_LITERAL
+    | SOCKET STRING_LITERAL
+    | OWNER STRING_LITERAL
+    | PORT decimalLiteral
+    ;
+
+createDefinitions
+    : '(' createDefinition (',' createDefinition)* ')'
+    ;
+
+createDefinition
+    : fullColumnName columnDefinition                               #columnDeclaration
+    | tableConstraint NOT? ENFORCED?                                #constraintDeclaration
+    | indexColumnDefinition                                         #indexDeclaration
+    ;
+
+columnDefinition
+    : dataType columnConstraint* NOT? ENFORCED?
+    ;
+
+columnConstraint
+    : nullNotnull                                                   #nullColumnConstraint
+    | DEFAULT defaultValue                                          #defaultColumnConstraint
+    | VISIBLE                                                       #visibilityColumnConstraint
+    | INVISIBLE                                                     #invisibilityColumnConstraint
+    | (AUTO_INCREMENT | ON UPDATE currentTimestamp)                 #autoIncrementColumnConstraint
+    | PRIMARY? KEY                                                  #primaryKeyColumnConstraint
+    | UNIQUE KEY?                                                   #uniqueKeyColumnConstraint
+    | COMMENT STRING_LITERAL                                        #commentColumnConstraint
+    | COLUMN_FORMAT colformat=(FIXED | DYNAMIC | DEFAULT)           #formatColumnConstraint
+    | STORAGE storageval=(DISK | MEMORY | DEFAULT)                  #storageColumnConstraint
+    | referenceDefinition                                           #referenceColumnConstraint
+    | COLLATE collationName                                         #collateColumnConstraint
+    | (GENERATED ALWAYS)? AS '(' expression ')' (VIRTUAL | STORED)? #generatedColumnConstraint
+    | SERIAL DEFAULT VALUE                                          #serialDefaultColumnConstraint
+    | (CONSTRAINT name=uid?)?
+      CHECK '(' expression ')'                                      #checkColumnConstraint
+    ;
+
+tableConstraint
+    : (CONSTRAINT name=uid?)?
+      PRIMARY KEY index=uid? indexType?
+      indexColumnNames indexOption*                                 #primaryKeyTableConstraint
+    | (CONSTRAINT name=uid?)?
+      UNIQUE indexFormat=(INDEX | KEY)? index=uid?
+      indexType? indexColumnNames indexOption*                      #uniqueKeyTableConstraint
+    | (CONSTRAINT name=uid?)?
+      FOREIGN KEY index=uid? indexColumnNames
+      referenceDefinition                                           #foreignKeyTableConstraint
+    | (CONSTRAINT name=uid?)?
+      CHECK '(' expression ')'                                      #checkTableConstraint
+    ;
+
+referenceDefinition
+    : REFERENCES tableName indexColumnNames?
+      (MATCH matchType=(FULL | PARTIAL | SIMPLE))?
+      referenceAction?
+    ;
+
+referenceAction
+    : ON DELETE onDelete=referenceControlType
+      (
+        ON UPDATE onUpdate=referenceControlType
+      )?
+    | ON UPDATE onUpdate=referenceControlType
+      (
+        ON DELETE onDelete=referenceControlType
+      )?
+    ;
+
+referenceControlType
+    : RESTRICT | CASCADE | SET NULL_LITERAL | NO ACTION | SET DEFAULT
+    ;
+
+indexColumnDefinition
+    : indexFormat=(INDEX | KEY) uid? indexType?
+      indexColumnNames indexOption*                                 #simpleIndexDeclaration
+    | (FULLTEXT | SPATIAL)
+      indexFormat=(INDEX | KEY)? uid?
+      indexColumnNames indexOption*                                 #specialIndexDeclaration
+    ;
+
+tableOption
+    : ENGINE '='? engineName?                                                       #tableOptionEngine
+    | ENGINE_ATTRIBUTE '='? STRING_LITERAL                                          #tableOptionEngineAttribute
+    | AUTOEXTEND_SIZE '='? decimalLiteral                                           #tableOptionAutoextendSize
+    | AUTO_INCREMENT '='? decimalLiteral                                            #tableOptionAutoIncrement
+    | AVG_ROW_LENGTH '='? decimalLiteral                                            #tableOptionAverage
+    | DEFAULT? charSet '='? (charsetName|DEFAULT)                                   #tableOptionCharset
+    | (CHECKSUM | PAGE_CHECKSUM) '='? boolValue=('0' | '1')                         #tableOptionChecksum
+    | DEFAULT? COLLATE '='? collationName                                           #tableOptionCollate
+    | COMMENT '='? STRING_LITERAL                                                   #tableOptionComment
+    | COMPRESSION '='? (STRING_LITERAL | ID)                                        #tableOptionCompression
+    | CONNECTION '='? STRING_LITERAL                                                #tableOptionConnection
+    | (DATA | INDEX) DIRECTORY '='? STRING_LITERAL                                  #tableOptionDataDirectory
+    | DELAY_KEY_WRITE '='? boolValue=('0' | '1')                                    #tableOptionDelay
+    | ENCRYPTION '='? STRING_LITERAL                                                #tableOptionEncryption
+    | (PAGE_COMPRESSED | STRING_LITERAL) '='? ('0' | '1')                           #tableOptionPageCompressed
+    | (PAGE_COMPRESSION_LEVEL | STRING_LITERAL) '='? decimalLiteral                 #tableOptionPageCompressionLevel
+    | ENCRYPTION_KEY_ID '='? decimalLiteral                                         #tableOptionEncryptionKeyId
+    | INDEX DIRECTORY '='? STRING_LITERAL                                           #tableOptionIndexDirectory
+    | INSERT_METHOD '='? insertMethod=(NO | FIRST | LAST)                           #tableOptionInsertMethod
+    | KEY_BLOCK_SIZE '='? fileSizeLiteral                                           #tableOptionKeyBlockSize
+    | MAX_ROWS '='? decimalLiteral                                                  #tableOptionMaxRows
+    | MIN_ROWS '='? decimalLiteral                                                  #tableOptionMinRows
+    | PACK_KEYS '='? extBoolValue=('0' | '1' | DEFAULT)                             #tableOptionPackKeys
+    | PASSWORD '='? STRING_LITERAL                                                  #tableOptionPassword
+    | ROW_FORMAT '='?
+        rowFormat=(
+          DEFAULT | DYNAMIC | FIXED | COMPRESSED
+          | REDUNDANT | COMPACT | ID
+        )                                                                           #tableOptionRowFormat
+    | START TRANSACTION                                                             #tableOptionStartTransaction
+    | SECONDARY_ENGINE_ATTRIBUTE '='? STRING_LITERAL                                #tableOptionSecondaryEngineAttribute
+    | STATS_AUTO_RECALC '='? extBoolValue=(DEFAULT | '0' | '1')                     #tableOptionRecalculation
+    | STATS_PERSISTENT '='? extBoolValue=(DEFAULT | '0' | '1')                      #tableOptionPersistent
+    | STATS_SAMPLE_PAGES '='? (DEFAULT | decimalLiteral)                            #tableOptionSamplePage
+    | TABLESPACE uid tablespaceStorage?                                             #tableOptionTablespace
+    | TABLE_TYPE '=' tableType                                                      #tableOptionTableType
+    | tablespaceStorage                                                             #tableOptionTablespace
+    | TRANSACTIONAL '='? ('0' | '1')                                                #tableOptionTransactional
+    | UNION '='? '(' tables ')'                                                     #tableOptionUnion
+    ;
+
+tableType
+    : MYSQL | ODBC
+    ;
+
+tablespaceStorage
+    : STORAGE (DISK | MEMORY | DEFAULT)
+    ;
+
+partitionDefinitions
+    : PARTITION BY partitionFunctionDefinition
+      (PARTITIONS count=decimalLiteral)?
+      (
+        SUBPARTITION BY subpartitionFunctionDefinition
+        (SUBPARTITIONS subCount=decimalLiteral)?
+      )?
+    ('(' partitionDefinition (',' partitionDefinition)* ')')?
+    ;
+
+partitionFunctionDefinition
+    : LINEAR? HASH '(' expression ')'                               #partitionFunctionHash
+    | LINEAR? KEY (ALGORITHM '=' algType=('1' | '2'))?
+      '(' uidList? ')'                                              #partitionFunctionKey // Optional uidList for MySQL only
+    | RANGE ( '(' expression ')' | COLUMNS '(' uidList ')' )        #partitionFunctionRange
+    | LIST ( '(' expression ')' | COLUMNS '(' uidList ')' )         #partitionFunctionList
+    ;
+
+subpartitionFunctionDefinition
+    : LINEAR? HASH '(' expression ')'                               #subPartitionFunctionHash
+    | LINEAR? KEY (ALGORITHM '=' algType=('1' | '2'))?
+      '(' uidList ')'                                               #subPartitionFunctionKey
+    ;
+
+partitionDefinition
+    : PARTITION uid VALUES LESS THAN
+      '('
+          partitionDefinerAtom (',' partitionDefinerAtom)*
+      ')'
+      partitionOption*
+      ( '(' subpartitionDefinition (',' subpartitionDefinition)* ')' )?       #partitionComparison
+    | PARTITION uid VALUES LESS THAN
+      partitionDefinerAtom partitionOption*
+      ( '(' subpartitionDefinition (',' subpartitionDefinition)* ')' )?       #partitionComparison
+    | PARTITION uid VALUES IN
+      '('
+          partitionDefinerAtom (',' partitionDefinerAtom)*
+      ')'
+      partitionOption*
+      ( '(' subpartitionDefinition (',' subpartitionDefinition)* ')' )?       #partitionListAtom
+    | PARTITION uid VALUES IN
+      '('
+          partitionDefinerVector (',' partitionDefinerVector)*
+      ')'
+      partitionOption*
+      ( '(' subpartitionDefinition (',' subpartitionDefinition)* ')' )?       #partitionListVector
+    | PARTITION uid partitionOption*
+      ( '(' subpartitionDefinition (',' subpartitionDefinition)* ')' )?       #partitionSimple
+    ;
+
+partitionDefinerAtom
+    : constant | expression | MAXVALUE
+    ;
+
+partitionDefinerVector
+    : '(' partitionDefinerAtom (',' partitionDefinerAtom)+ ')'
+    ;
+
+subpartitionDefinition
+    : SUBPARTITION uid partitionOption*
+    ;
+
+partitionOption
+    : DEFAULT? STORAGE? ENGINE '='? engineName                      #partitionOptionEngine
+    | COMMENT '='? comment=STRING_LITERAL                           #partitionOptionComment
+    | DATA DIRECTORY '='? dataDirectory=STRING_LITERAL              #partitionOptionDataDirectory
+    | INDEX DIRECTORY '='? indexDirectory=STRING_LITERAL            #partitionOptionIndexDirectory
+    | MAX_ROWS '='? maxRows=decimalLiteral                          #partitionOptionMaxRows
+    | MIN_ROWS '='? minRows=decimalLiteral                          #partitionOptionMinRows
+    | TABLESPACE '='? tablespace=uid                                #partitionOptionTablespace
+    | NODEGROUP '='? nodegroup=uid                                  #partitionOptionNodeGroup
+    ;
+
+//    Alter statements
+
+alterDatabase
+    : ALTER dbFormat=(DATABASE | SCHEMA) uid?
+      createDatabaseOption+                                         #alterSimpleDatabase
+    | ALTER dbFormat=(DATABASE | SCHEMA) uid
+      UPGRADE DATA DIRECTORY NAME                                   #alterUpgradeName
+    ;
+
+alterEvent
+    : ALTER ownerStatement?
+      EVENT fullId
+      (ON SCHEDULE scheduleExpression)?
+      (ON COMPLETION NOT? PRESERVE)?
+      (RENAME TO fullId)? enableType?
+      (COMMENT STRING_LITERAL)?
+      (DO routineBody)?
+    ;
+
+alterFunction
+    : ALTER FUNCTION fullId routineOption*
+    ;
+
+alterInstance
+    : ALTER INSTANCE ROTATE INNODB MASTER KEY
+    ;
+
+alterLogfileGroup
+    : ALTER LOGFILE GROUP uid
+      ADD UNDOFILE STRING_LITERAL
+      (INITIAL_SIZE '='? fileSizeLiteral)?
+      WAIT? ENGINE '='? engineName
+    ;
+
+alterProcedure
+    : ALTER PROCEDURE fullId routineOption*
+    ;
+
+alterServer
+    : ALTER SERVER uid OPTIONS
+      '(' serverOption (',' serverOption)* ')'
+    ;
+
+alterTable
+    : ALTER intimeAction=(ONLINE | OFFLINE)?
+      IGNORE? TABLE tableName waitNowaitClause?
+      (alterSpecification (',' alterSpecification)*)?
+      partitionDefinitions?
+    ;
+
+alterTablespace
+    : ALTER TABLESPACE uid
+      objectAction=(ADD | DROP) DATAFILE STRING_LITERAL
+      (INITIAL_SIZE '=' fileSizeLiteral)?
+      WAIT?
+      ENGINE '='? engineName
+    ;
+
+alterView
+    : ALTER
+      (
+        ALGORITHM '=' algType=(UNDEFINED | MERGE | TEMPTABLE)
+      )?
+      ownerStatement?
+      (SQL SECURITY secContext=(DEFINER | INVOKER))?
+      VIEW fullId ('(' uidList ')')? AS selectStatement
+      (WITH checkOpt=(CASCADED | LOCAL)? CHECK OPTION)?
+    ;
+
+// details
+
+alterSpecification
+    : tableOption (','? tableOption)*                               #alterByTableOption
+    | ADD COLUMN? uid columnDefinition (FIRST | AFTER uid)?         #alterByAddColumn
+    | ADD COLUMN?
+        '('
+          uid columnDefinition ( ',' uid columnDefinition)*
+        ')'                                                         #alterByAddColumns
+    | ADD indexFormat=(INDEX | KEY) uid? indexType?
+      indexColumnNames indexOption*                                 #alterByAddIndex
+    | ADD (CONSTRAINT name=uid?)? PRIMARY KEY index=uid?
+      indexType? indexColumnNames indexOption*                      #alterByAddPrimaryKey
+    | ADD (CONSTRAINT name=uid?)? UNIQUE
+      indexFormat=(INDEX | KEY)? indexName=uid?
+      indexType? indexColumnNames indexOption*                      #alterByAddUniqueKey
+    | ADD keyType=(FULLTEXT | SPATIAL)
+      indexFormat=(INDEX | KEY)? uid?
+      indexColumnNames indexOption*                                 #alterByAddSpecialIndex
+    | ADD (CONSTRAINT name=uid?)? FOREIGN KEY
+      indexName=uid? indexColumnNames referenceDefinition           #alterByAddForeignKey
+    | ADD (CONSTRAINT name=uid?)? CHECK ( uid | stringLiteral | '(' expression ')' )
+      NOT? ENFORCED?                                                #alterByAddCheckTableConstraint
+    | ALTER (CONSTRAINT name=uid?)? CHECK ( uid | stringLiteral | '(' expression ')' )
+      NOT? ENFORCED?                                                #alterByAlterCheckTableConstraint
+    | ADD (CONSTRAINT name=uid?)? CHECK '(' expression ')'          #alterByAddCheckTableConstraint
+    | ALGORITHM '='? algType=(DEFAULT | INSTANT | INPLACE | COPY)   #alterBySetAlgorithm
+    | ALTER COLUMN? uid
+      (SET DEFAULT defaultValue | DROP DEFAULT)                     #alterByChangeDefault
+    | CHANGE COLUMN? oldColumn=uid
+      newColumn=uid columnDefinition
+      (FIRST | AFTER afterColumn=uid)?                              #alterByChangeColumn
+    | RENAME COLUMN oldColumn=uid TO newColumn=uid                  #alterByRenameColumn
+    | LOCK '='? lockType=(DEFAULT | NONE | SHARED | EXCLUSIVE)      #alterByLock
+    | MODIFY COLUMN?
+      uid columnDefinition (FIRST | AFTER uid)?                     #alterByModifyColumn
+    | DROP COLUMN? uid RESTRICT?                                    #alterByDropColumn
+    | DROP (CONSTRAINT | CHECK) uid                                 #alterByDropConstraintCheck
+    | DROP PRIMARY KEY                                              #alterByDropPrimaryKey
+    | DROP indexFormat=(INDEX | KEY) uid                            #alterByDropIndex
+    | RENAME indexFormat=(INDEX | KEY) uid TO uid                   #alterByRenameIndex
+    | ALTER COLUMN? uid (
+        SET DEFAULT ( stringLiteral | '(' expression ')' )
+        | SET (VISIBLE | INVISIBLE)
+        | DROP DEFAULT)                                             #alterByAlterColumnDefault
+    | ALTER INDEX uid (VISIBLE | INVISIBLE)                         #alterByAlterIndexVisibility
+    | DROP FOREIGN KEY uid                                          #alterByDropForeignKey
+    | DISABLE KEYS                                                  #alterByDisableKeys
+    | ENABLE KEYS                                                   #alterByEnableKeys
+    | RENAME renameFormat=(TO | AS)? (uid | fullId)                 #alterByRename
+    | ORDER BY uidList                                              #alterByOrder
+    | CONVERT TO (CHARSET | CHARACTER SET) charsetName
+      (COLLATE collationName)?                                      #alterByConvertCharset
+    | DEFAULT? CHARACTER SET '=' charsetName
+      (COLLATE '=' collationName)?                                  #alterByDefaultCharset
+    | DISCARD TABLESPACE                                            #alterByDiscardTablespace
+    | IMPORT TABLESPACE                                             #alterByImportTablespace
+    | FORCE                                                         #alterByForce
+    | validationFormat=(WITHOUT | WITH) VALIDATION                  #alterByValidate
+    | ADD PARTITION
+        '('
+          partitionDefinition (',' partitionDefinition)*
+        ')'                                                         #alterByAddPartition
+    | DROP PARTITION uidList                                        #alterByDropPartition
+    | DISCARD PARTITION (uidList | ALL) TABLESPACE                  #alterByDiscardPartition
+    | IMPORT PARTITION (uidList | ALL) TABLESPACE                   #alterByImportPartition
+    | TRUNCATE PARTITION (uidList | ALL)                            #alterByTruncatePartition
+    | COALESCE PARTITION decimalLiteral                             #alterByCoalescePartition
+    | REORGANIZE PARTITION uidList
+        INTO '('
+          partitionDefinition (',' partitionDefinition)*
+        ')'                                                         #alterByReorganizePartition
+    | EXCHANGE PARTITION uid WITH TABLE tableName
+      (validationFormat=(WITH | WITHOUT) VALIDATION)?               #alterByExchangePartition
+    | ANALYZE PARTITION (uidList | ALL)                             #alterByAnalyzePartition
+    | CHECK PARTITION (uidList | ALL)                               #alterByCheckPartition
+    | OPTIMIZE PARTITION (uidList | ALL)                            #alterByOptimizePartition
+    | REBUILD PARTITION (uidList | ALL)                             #alterByRebuildPartition
+    | REPAIR PARTITION (uidList | ALL)                              #alterByRepairPartition
+    | REMOVE PARTITIONING                                           #alterByRemovePartitioning
+    | UPGRADE PARTITIONING                                          #alterByUpgradePartitioning
+    | ADD COLUMN?
+        '(' createDefinition (',' createDefinition)* ')'            #alterByAddDefinitions
+    ;
+
+
+//    Drop statements
+
+dropDatabase
+    : DROP dbFormat=(DATABASE | SCHEMA) ifExists? uid
+    ;
+
+dropEvent
+    : DROP EVENT ifExists? fullId
+    ;
+
+dropIndex
+    : DROP INDEX intimeAction=(ONLINE | OFFLINE)?
+      uid ON tableName
+      (
+        ALGORITHM '='? algType=(DEFAULT | INPLACE | COPY)
+        | LOCK '='?
+          lockType=(DEFAULT | NONE | SHARED | EXCLUSIVE)
+      )*
+    ;
+
+dropLogfileGroup
+    : DROP LOGFILE GROUP uid ENGINE '=' engineName
+    ;
+
+dropProcedure
+    : DROP PROCEDURE ifExists? fullId
+    ;
+
+dropFunction
+    : DROP FUNCTION ifExists? fullId
+    ;
+
+dropServer
+    : DROP SERVER ifExists? uid
+    ;
+
+dropTable
+    : DROP TEMPORARY? TABLE ifExists?
+      tables dropType=(RESTRICT | CASCADE)?
+    ;
+
+dropTablespace
+    : DROP TABLESPACE uid (ENGINE '='? engineName)?
+    ;
+
+dropTrigger
+    : DROP TRIGGER ifExists? fullId
+    ;
+
+dropView
+    : DROP VIEW ifExists?
+      fullId (',' fullId)* dropType=(RESTRICT | CASCADE)?
+    ;
+
+dropRole
+    : DROP ROLE ifExists? roleName (',' roleName)*
+    ;
+
+setRole
+    : SET DEFAULT ROLE (NONE | ALL | roleName (',' roleName)*)
+      TO (userName | uid) (',' (userName | uid))*
+    | SET ROLE roleOption
+    ;
+
+//    Other DDL statements
+
+renameTable
+    : RENAME TABLE
+    renameTableClause (',' renameTableClause)*
+    ;
+
+renameTableClause
+    : tableName TO tableName
+    ;
+
+truncateTable
+    : TRUNCATE TABLE? tableName
+    ;
+
+
+// Data Manipulation Language
+
+//    Primary DML Statements
+
+
+callStatement
+    : CALL fullId
+      (
+        '(' (constants | expressions)? ')'
+      )?
+    ;
+
+deleteStatement
+    : singleDeleteStatement | multipleDeleteStatement
+    ;
+
+doStatement
+    : DO expressions
+    ;
+
+handlerStatement
+    : handlerOpenStatement
+    | handlerReadIndexStatement
+    | handlerReadStatement
+    | handlerCloseStatement
+    ;
+
+insertStatement
+    : INSERT
+      priority=(LOW_PRIORITY | DELAYED | HIGH_PRIORITY)?
+      IGNORE? INTO? tableName
+      (PARTITION '(' partitions=uidList? ')' )?
+      (
+        ('(' columns=fullColumnNameList ')')? insertStatementValue
+        | SET
+            setFirst=updatedElement
+            (',' setElements+=updatedElement)*
+      )
+      (
+        ON DUPLICATE KEY UPDATE
+        duplicatedFirst=updatedElement
+        (',' duplicatedElements+=updatedElement)*
+      )?
+    ;
+
+loadDataStatement
+    : LOAD DATA
+      priority=(LOW_PRIORITY | CONCURRENT)?
+      LOCAL? INFILE filename=STRING_LITERAL
+      violation=(REPLACE | IGNORE)?
+      INTO TABLE tableName
+      (PARTITION '(' uidList ')' )?
+      (CHARACTER SET charset=charsetName)?
+      (
+        fieldsFormat=(FIELDS | COLUMNS)
+        selectFieldsInto+
+      )?
+      (
+        LINES
+          selectLinesInto+
+      )?
+      (
+        IGNORE decimalLiteral linesFormat=(LINES | ROWS)
+      )?
+      ( '(' assignmentField (',' assignmentField)* ')' )?
+      (SET updatedElement (',' updatedElement)*)?
+    ;
+
+loadXmlStatement
+    : LOAD XML
+      priority=(LOW_PRIORITY | CONCURRENT)?
+      LOCAL? INFILE filename=STRING_LITERAL
+      violation=(REPLACE | IGNORE)?
+      INTO TABLE tableName
+      (CHARACTER SET charset=charsetName)?
+      (ROWS IDENTIFIED BY '<' tag=STRING_LITERAL '>')?
+      ( IGNORE decimalLiteral linesFormat=(LINES | ROWS) )?
+      ( '(' assignmentField (',' assignmentField)* ')' )?
+      (SET updatedElement (',' updatedElement)*)?
+    ;
+
+replaceStatement
+    : REPLACE priority=(LOW_PRIORITY | DELAYED)?
+      INTO? tableName
+      (PARTITION '(' partitions=uidList ')' )?
+      (
+        ('(' columns=uidList ')')? insertStatementValue
+        | SET
+          setFirst=updatedElement
+          (',' setElements+=updatedElement)*
+      )
+    ;
+
+selectStatement
+    : querySpecification lockClause?                                #simpleSelect
+    | queryExpression lockClause?                                   #parenthesisSelect
+    | querySpecificationNointo unionStatement+
+        (
+          UNION unionType=(ALL | DISTINCT)?
+          (querySpecification | queryExpression)
+        )?
+        orderByClause? limitClause? lockClause?                     #unionSelect
+    | queryExpressionNointo unionParenthesis+
+        (
+          UNION unionType=(ALL | DISTINCT)?
+          queryExpression
+        )?
+        orderByClause? limitClause? lockClause?                     #unionParenthesisSelect
+    | querySpecificationNointo (',' lateralStatement)+              #withLateralStatement
+    ;
+
+updateStatement
+    : singleUpdateStatement | multipleUpdateStatement
+    ;
+
+// https://dev.mysql.com/doc/refman/8.0/en/values.html
+valuesStatement
+    : VALUES
+    '(' expressionsWithDefaults? ')'
+    (',' '(' expressionsWithDefaults? ')')*
+    ;
+
+// details
+
+insertStatementValue
+    : selectStatement
+    | insertFormat=(VALUES | VALUE)
+      '(' expressionsWithDefaults? ')'
+        (',' '(' expressionsWithDefaults? ')')*
+    ;
+
+updatedElement
+    : fullColumnName '=' (expression | DEFAULT)
+    ;
+
+assignmentField
+    : uid | LOCAL_ID
+    ;
+
+lockClause
+    : FOR UPDATE | LOCK IN SHARE MODE
+    ;
+
+//    Detailed DML Statements
+
+singleDeleteStatement
+    : DELETE priority=LOW_PRIORITY? QUICK? IGNORE?
+    FROM tableName
+      (PARTITION '(' uidList ')' )?
+      (WHERE expression)?
+      orderByClause? (LIMIT limitClauseAtom)?
+    ;
+
+multipleDeleteStatement
+    : DELETE priority=LOW_PRIORITY? QUICK? IGNORE?
+      (
+        tableName ('.' '*')? ( ',' tableName ('.' '*')? )*
+            FROM tableSources
+        | FROM
+            tableName ('.' '*')? ( ',' tableName ('.' '*')? )*
+            USING tableSources
+      )
+      (WHERE expression)?
+    ;
+
+handlerOpenStatement
+    : HANDLER tableName OPEN (AS? uid)?
+    ;
+
+handlerReadIndexStatement
+    : HANDLER tableName READ index=uid
+      (
+        comparisonOperator '(' constants ')'
+        | moveOrder=(FIRST | NEXT | PREV | LAST)
+      )
+      (WHERE expression)? (LIMIT limitClauseAtom)?
+    ;
+
+handlerReadStatement
+    : HANDLER tableName READ moveOrder=(FIRST | NEXT)
+      (WHERE expression)? (LIMIT limitClauseAtom)?
+    ;
+
+handlerCloseStatement
+    : HANDLER tableName CLOSE
+    ;
+
+singleUpdateStatement
+    : UPDATE priority=LOW_PRIORITY? IGNORE? tableName (AS? uid)?
+      SET updatedElement (',' updatedElement)*
+      (WHERE expression)? orderByClause? limitClause?
+    ;
+
+multipleUpdateStatement
+    : UPDATE priority=LOW_PRIORITY? IGNORE? tableSources
+      SET updatedElement (',' updatedElement)*
+      (WHERE expression)?
+    ;
+
+// details
+
+orderByClause
+    : ORDER BY orderByExpression (',' orderByExpression)*
+    ;
+
+orderByExpression
+    : expression order=(ASC | DESC)?
+    ;
+
+tableSources
+    : tableSource (',' tableSource)*
+    ;
+
+tableSource
+    : tableSourceItem joinPart*                                     #tableSourceBase
+    | '(' tableSourceItem joinPart* ')'                             #tableSourceNested
+    | jsonTable                                                     #tableJson
+    ;
+
+tableSourceItem
+    : tableName
+      (PARTITION '(' uidList ')' )? (AS? alias=uid)?
+      (indexHint (',' indexHint)* )?                                #atomTableItem
+    | (
+      selectStatement
+      | '(' parenthesisSubquery=selectStatement ')'
+      )
+      AS? alias=uid                                                 #subqueryTableItem
+    | '(' tableSources ')'                                          #tableSourcesItem
+    ;
+
+indexHint
+    : indexHintAction=(USE | IGNORE | FORCE)
+      keyFormat=(INDEX|KEY) ( FOR indexHintType)?
+      '(' uidList ')'
+    ;
+
+indexHintType
+    : JOIN | ORDER BY | GROUP BY
+    ;
+
+joinPart
+    : (INNER | CROSS)? JOIN LATERAL? tableSourceItem
+      (
+        ON expression
+        | USING '(' uidList ')'
+      )?                                                            #innerJoin
+    | STRAIGHT_JOIN tableSourceItem (ON expression)?                #straightJoin
+    | (LEFT | RIGHT) OUTER? JOIN LATERAL? tableSourceItem
+        (
+          ON expression
+          | USING '(' uidList ')'
+        )                                                           #outerJoin
+    | NATURAL ((LEFT | RIGHT) OUTER?)? JOIN tableSourceItem         #naturalJoin
+    ;
+
+//    Select Statement's Details
+
+queryExpression
+    : '(' querySpecification ')'
+    | '(' queryExpression ')'
+    ;
+
+queryExpressionNointo
+    : '(' querySpecificationNointo ')'
+    | '(' queryExpressionNointo ')'
+    ;
+
+querySpecification
+    : SELECT selectSpec* selectElements selectIntoExpression?
+      fromClause groupByClause? havingClause? windowClause? orderByClause? limitClause?
+    | SELECT selectSpec* selectElements
+    fromClause groupByClause? havingClause? windowClause? orderByClause? limitClause? selectIntoExpression?
+    ;
+
+querySpecificationNointo
+    : SELECT selectSpec* selectElements
+      fromClause groupByClause? havingClause? windowClause? orderByClause? limitClause?
+    ;
+
+unionParenthesis
+    : UNION unionType=(ALL | DISTINCT)? queryExpressionNointo
+    ;
+
+unionStatement
+    : UNION unionType=(ALL | DISTINCT)?
+      (querySpecificationNointo | queryExpressionNointo)
+    ;
+
+lateralStatement
+    : LATERAL (querySpecificationNointo |
+               queryExpressionNointo |
+               ('(' (querySpecificationNointo | queryExpressionNointo) ')' (AS? uid)?)
+              )
+    ;
+
+// JSON
+
+// https://dev.mysql.com/doc/refman/8.0/en/json-table-functions.html
+jsonTable
+    : JSON_TABLE '('
+        STRING_LITERAL ','
+        STRING_LITERAL
+        COLUMNS '(' jsonColumnList ')'
+      ')' (AS? uid)?
+    ;
+
+jsonColumnList
+    : jsonColumn (',' jsonColumn)*
+    ;
+
+jsonColumn
+    : fullColumnName ( FOR ORDINALITY
+                     | dataType ( PATH STRING_LITERAL jsonOnEmpty? jsonOnError?
+                                | EXISTS PATH STRING_LITERAL ) )
+    | NESTED PATH? STRING_LITERAL COLUMNS '(' jsonColumnList ')'
+    ;
+
+jsonOnEmpty
+    : (NULL_LITERAL | ERROR | DEFAULT defaultValue) ON EMPTY
+    ;
+
+jsonOnError
+    : (NULL_LITERAL | ERROR | DEFAULT defaultValue) ON ERROR
+    ;
+
+// details
+
+selectSpec
+    : (ALL | DISTINCT | DISTINCTROW)
+    | HIGH_PRIORITY | STRAIGHT_JOIN | SQL_SMALL_RESULT
+    | SQL_BIG_RESULT | SQL_BUFFER_RESULT
+    | (SQL_CACHE | SQL_NO_CACHE)
+    | SQL_CALC_FOUND_ROWS
+    ;
+
+selectElements
+    : (star='*' | selectElement ) (',' selectElement)*
+    ;
+
+selectElement
+    : fullId '.' '*'                                                #selectStarElement
+    | fullColumnName (AS? uid)?                                     #selectColumnElement
+    | functionCall (AS? uid)?                                       #selectFunctionElement
+    | (LOCAL_ID VAR_ASSIGN)? expression (AS? uid)?                  #selectExpressionElement
+    ;
+
+selectIntoExpression
+    : INTO assignmentField (',' assignmentField )*                  #selectIntoVariables
+    | INTO DUMPFILE STRING_LITERAL                                  #selectIntoDumpFile
+    | (
+        INTO OUTFILE filename=STRING_LITERAL
+        (CHARACTER SET charset=charsetName)?
+        (
+          fieldsFormat=(FIELDS | COLUMNS)
+          selectFieldsInto+
+        )?
+        (
+          LINES selectLinesInto+
+        )?
+      )                                                             #selectIntoTextFile
+    ;
+
+selectFieldsInto
+    : TERMINATED BY terminationField=STRING_LITERAL
+    | OPTIONALLY? ENCLOSED BY enclosion=STRING_LITERAL
+    | ESCAPED BY escaping=STRING_LITERAL
+    ;
+
+selectLinesInto
+    : STARTING BY starting=STRING_LITERAL
+    | TERMINATED BY terminationLine=STRING_LITERAL
+    ;
+
+fromClause
+    : (FROM tableSources)?
+      (WHERE whereExpr=expression)?
+    ;
+
+groupByClause
+    :  GROUP BY
+        groupByItem (',' groupByItem)*
+        (WITH ROLLUP)?
+    ;
+
+havingClause
+    :  HAVING havingExpr=expression
+    ;
+
+windowClause
+    :  WINDOW windowName AS '(' windowSpec ')' (',' windowName AS '(' windowSpec ')')*
+    ;
+
+groupByItem
+    : expression order=(ASC | DESC)?
+    ;
+
+limitClause
+    : LIMIT
+    (
+      (offset=limitClauseAtom ',')? limit=limitClauseAtom
+      | limit=limitClauseAtom OFFSET offset=limitClauseAtom
+    )
+    ;
+
+limitClauseAtom
+	: decimalLiteral | mysqlVariable | simpleId
+	;
+
+
+// Transaction's Statements
+
+startTransaction
+    : START TRANSACTION (transactionMode (',' transactionMode)* )?
+    ;
+
+beginWork
+    : BEGIN WORK?
+    ;
+
+commitWork
+    : COMMIT WORK?
+      (AND nochain=NO? CHAIN)?
+      (norelease=NO? RELEASE)?
+    ;
+
+rollbackWork
+    : ROLLBACK WORK?
+      (AND nochain=NO? CHAIN)?
+      (norelease=NO? RELEASE)?
+    ;
+
+savepointStatement
+    : SAVEPOINT uid
+    ;
+
+rollbackStatement
+    : ROLLBACK WORK? TO SAVEPOINT? uid
+    ;
+
+releaseStatement
+    : RELEASE SAVEPOINT uid
+    ;
+
+lockTables
+    : LOCK (TABLE | TABLES) lockTableElement (',' lockTableElement)* waitNowaitClause?
+    ;
+
+unlockTables
+    : UNLOCK TABLES
+    ;
+
+
+// details
+
+setAutocommitStatement
+    : SET AUTOCOMMIT '=' autocommitValue=('0' | '1')
+    ;
+
+setTransactionStatement
+    : SET transactionContext=(GLOBAL | SESSION)? TRANSACTION
+      transactionOption (',' transactionOption)*
+    ;
+
+transactionMode
+    : WITH CONSISTENT SNAPSHOT
+    | READ WRITE
+    | READ ONLY
+    ;
+
+lockTableElement
+    : tableName (AS? uid)? lockAction
+    ;
+
+lockAction
+    : READ LOCAL? | LOW_PRIORITY? WRITE
+    ;
+
+transactionOption
+    : ISOLATION LEVEL transactionLevel
+    | READ WRITE
+    | READ ONLY
+    ;
+
+transactionLevel
+    : REPEATABLE READ
+    | READ COMMITTED
+    | READ UNCOMMITTED
+    | SERIALIZABLE
+    ;
+
+
+// Replication's Statements
+
+//    Base Replication
+
+changeMaster
+    : CHANGE MASTER TO
+      masterOption (',' masterOption)* channelOption?
+    ;
+
+changeReplicationFilter
+    : CHANGE REPLICATION FILTER
+      replicationFilter (',' replicationFilter)*
+    ;
+
+purgeBinaryLogs
+    : PURGE purgeFormat=(BINARY | MASTER) LOGS
+       (
+           TO fileName=STRING_LITERAL
+           | BEFORE timeValue=STRING_LITERAL
+       )
+    ;
+
+resetMaster
+    : RESET MASTER
+    ;
+
+resetSlave
+    : RESET SLAVE ALL? channelOption?
+    ;
+
+startSlave
+    : START SLAVE (threadType (',' threadType)*)?
+      (UNTIL untilOption)?
+      connectionOption* channelOption?
+    ;
+
+stopSlave
+    : STOP SLAVE (threadType (',' threadType)*)?
+    ;
+
+startGroupReplication
+    : START GROUP_REPLICATION
+    ;
+
+stopGroupReplication
+    : STOP GROUP_REPLICATION
+    ;
+
+// details
+
+masterOption
+    : stringMasterOption '=' STRING_LITERAL                         #masterStringOption
+    | decimalMasterOption '=' decimalLiteral                        #masterDecimalOption
+    | boolMasterOption '=' boolVal=('0' | '1')                      #masterBoolOption
+    | MASTER_HEARTBEAT_PERIOD '=' REAL_LITERAL                      #masterRealOption
+    | IGNORE_SERVER_IDS '=' '(' (uid (',' uid)*)? ')'               #masterUidListOption
+    ;
+
+stringMasterOption
+    : MASTER_BIND | MASTER_HOST | MASTER_USER | MASTER_PASSWORD
+    | MASTER_LOG_FILE | RELAY_LOG_FILE | MASTER_SSL_CA
+    | MASTER_SSL_CAPATH | MASTER_SSL_CERT | MASTER_SSL_CRL
+    | MASTER_SSL_CRLPATH | MASTER_SSL_KEY | MASTER_SSL_CIPHER
+    | MASTER_TLS_VERSION
+    ;
+decimalMasterOption
+    : MASTER_PORT | MASTER_CONNECT_RETRY | MASTER_RETRY_COUNT
+    | MASTER_DELAY | MASTER_LOG_POS | RELAY_LOG_POS
+    ;
+
+boolMasterOption
+    : MASTER_AUTO_POSITION | MASTER_SSL
+    | MASTER_SSL_VERIFY_SERVER_CERT
+    ;
+
+channelOption
+    : FOR CHANNEL STRING_LITERAL
+    ;
+
+replicationFilter
+    : REPLICATE_DO_DB '=' '(' uidList ')'                           #doDbReplication
+    | REPLICATE_IGNORE_DB '=' '(' uidList ')'                       #ignoreDbReplication
+    | REPLICATE_DO_TABLE '=' '(' tables ')'                         #doTableReplication
+    | REPLICATE_IGNORE_TABLE '=' '(' tables ')'                     #ignoreTableReplication
+    | REPLICATE_WILD_DO_TABLE '=' '(' simpleStrings ')'             #wildDoTableReplication
+    | REPLICATE_WILD_IGNORE_TABLE
+       '=' '(' simpleStrings ')'                                    #wildIgnoreTableReplication
+    | REPLICATE_REWRITE_DB '='
+      '(' tablePair (',' tablePair)* ')'                            #rewriteDbReplication
+    ;
+
+tablePair
+    : '(' firstTable=tableName ',' secondTable=tableName ')'
+    ;
+
+threadType
+    : IO_THREAD | SQL_THREAD
+    ;
+
+untilOption
+    : gtids=(SQL_BEFORE_GTIDS | SQL_AFTER_GTIDS)
+      '=' gtuidSet                                                  #gtidsUntilOption
+    | MASTER_LOG_FILE '=' STRING_LITERAL
+      ',' MASTER_LOG_POS '=' decimalLiteral                         #masterLogUntilOption
+    | RELAY_LOG_FILE '=' STRING_LITERAL
+      ',' RELAY_LOG_POS '=' decimalLiteral                          #relayLogUntilOption
+    | SQL_AFTER_MTS_GAPS                                            #sqlGapsUntilOption
+    ;
+
+connectionOption
+    : USER '=' conOptUser=STRING_LITERAL                            #userConnectionOption
+    | PASSWORD '=' conOptPassword=STRING_LITERAL                    #passwordConnectionOption
+    | DEFAULT_AUTH '=' conOptDefAuth=STRING_LITERAL                 #defaultAuthConnectionOption
+    | PLUGIN_DIR '=' conOptPluginDir=STRING_LITERAL                 #pluginDirConnectionOption
+    ;
+
+gtuidSet
+    : uuidSet (',' uuidSet)*
+    | STRING_LITERAL
+    ;
+
+
+//    XA Transactions
+
+xaStartTransaction
+    : XA xaStart=(START | BEGIN) xid xaAction=(JOIN | RESUME)?
+    ;
+
+xaEndTransaction
+    : XA END xid (SUSPEND (FOR MIGRATE)?)?
+    ;
+
+xaPrepareStatement
+    : XA PREPARE xid
+    ;
+
+xaCommitWork
+    : XA COMMIT xid (ONE PHASE)?
+    ;
+
+xaRollbackWork
+    : XA ROLLBACK xid
+    ;
+
+xaRecoverWork
+    : XA RECOVER (CONVERT xid)?
+    ;
+
+
+// Prepared Statements
+
+prepareStatement
+    : PREPARE uid FROM
+      (query=STRING_LITERAL | variable=LOCAL_ID)
+    ;
+
+executeStatement
+    : EXECUTE uid (USING userVariables)?
+    ;
+
+deallocatePrepare
+    : dropFormat=(DEALLOCATE | DROP) PREPARE uid
+    ;
+
+
+// Compound Statements
+
+routineBody
+    : blockStatement | sqlStatement
+    ;
+
+// details
+
+blockStatement
+    : (uid ':')? BEGIN
+        (declareVariable SEMI)*
+        (declareCondition SEMI)*
+        (declareCursor SEMI)*
+        (declareHandler SEMI)*
+        procedureSqlStatement*
+      END uid?
+    ;
+
+caseStatement
+    : CASE (uid | expression)? caseAlternative+
+      (ELSE procedureSqlStatement+)?
+      END CASE
+    ;
+
+ifStatement
+    : IF expression
+      THEN thenStatements+=procedureSqlStatement+
+      elifAlternative*
+      (ELSE elseStatements+=procedureSqlStatement+ )?
+      END IF
+    ;
+
+iterateStatement
+    : ITERATE uid
+    ;
+
+leaveStatement
+    : LEAVE uid
+    ;
+
+loopStatement
+    : (uid ':')?
+      LOOP procedureSqlStatement+
+      END LOOP uid?
+    ;
+
+repeatStatement
+    : (uid ':')?
+      REPEAT procedureSqlStatement+
+      UNTIL expression
+      END REPEAT uid?
+    ;
+
+returnStatement
+    : RETURN expression
+    ;
+
+whileStatement
+    : (uid ':')?
+      WHILE expression
+      DO procedureSqlStatement+
+      END WHILE uid?
+    ;
+
+cursorStatement
+    : CLOSE uid                                                     #CloseCursor
+    | FETCH (NEXT? FROM)? uid INTO uidList                          #FetchCursor
+    | OPEN uid                                                      #OpenCursor
+    ;
+
+// details
+
+declareVariable
+    : DECLARE uidList dataType (DEFAULT expression)?
+    ;
+
+declareCondition
+    : DECLARE uid CONDITION FOR
+      ( decimalLiteral | SQLSTATE VALUE? STRING_LITERAL)
+    ;
+
+declareCursor
+    : DECLARE uid CURSOR FOR selectStatement
+    ;
+
+declareHandler
+    : DECLARE handlerAction=(CONTINUE | EXIT | UNDO)
+      HANDLER FOR
+      handlerConditionValue (',' handlerConditionValue)*
+      routineBody
+    ;
+
+handlerConditionValue
+    : decimalLiteral                                                #handlerConditionCode
+    | SQLSTATE VALUE? STRING_LITERAL                                #handlerConditionState
+    | uid                                                           #handlerConditionName
+    | SQLWARNING                                                    #handlerConditionWarning
+    | NOT FOUND                                                     #handlerConditionNotfound
+    | SQLEXCEPTION                                                  #handlerConditionException
+    ;
+
+procedureSqlStatement
+    : (compoundStatement | sqlStatement) SEMI
+    ;
+
+caseAlternative
+    : WHEN (constant | expression)
+      THEN procedureSqlStatement+
+    ;
+
+elifAlternative
+    : ELSEIF expression
+      THEN procedureSqlStatement+
+    ;
+
+// Administration Statements
+
+//    Account management statements
+
+alterUser
+    : ALTER USER
+      userSpecification (',' userSpecification)*                    #alterUserMysqlV56
+    | ALTER USER ifExists?
+        userAuthOption (',' userAuthOption)*
+        (
+          REQUIRE
+          (tlsNone=NONE | tlsOption (AND? tlsOption)* )
+        )?
+        (WITH userResourceOption+)?
+        (userPasswordOption | userLockOption)*
+        (COMMENT STRING_LITERAL |  ATTRIBUTE STRING_LITERAL)?       #alterUserMysqlV80
+    | ALTER USER ifExists?
+      (userName | uid) DEFAULT ROLE roleOption                      #alterUserMysqlV80
+    ;
+
+createUser
+    : CREATE USER userAuthOption (',' userAuthOption)*              #createUserMysqlV56
+    | CREATE USER ifNotExists?
+        userAuthOption (',' userAuthOption)*
+        (DEFAULT ROLE roleOption)?
+        (
+          REQUIRE
+          (tlsNone=NONE | tlsOption (AND? tlsOption)* )
+        )?
+        (WITH userResourceOption+)?
+        (userPasswordOption | userLockOption)*
+        (COMMENT STRING_LITERAL |  ATTRIBUTE STRING_LITERAL)?       #createUserMysqlV80
+    ;
+
+dropUser
+    : DROP USER ifExists? userName (',' userName)*
+    ;
+
+grantStatement
+    : GRANT privelegeClause (',' privelegeClause)*
+      ON
+      privilegeObject=(TABLE | FUNCTION | PROCEDURE)?
+      privilegeLevel
+      TO userAuthOption (',' userAuthOption)*
+      (
+          REQUIRE
+          (tlsNone=NONE | tlsOption (AND? tlsOption)* )
+        )?
+      (WITH (GRANT OPTION | userResourceOption)* )?
+      (AS userName WITH ROLE roleOption)?
+    | GRANT (userName | uid) (',' (userName | uid))*
+      TO (userName | uid) (',' (userName | uid))*
+      (WITH ADMIN OPTION)?
+    ;
+
+roleOption
+    : DEFAULT
+    | NONE
+    | ALL (EXCEPT userName (',' userName)*)?
+    | userName (',' userName)*
+    ;
+
+grantProxy
+    : GRANT PROXY ON fromFirst=userName
+      TO toFirst=userName (',' toOther+=userName)*
+      (WITH GRANT OPTION)?
+    ;
+
+renameUser
+    : RENAME USER
+      renameUserClause (',' renameUserClause)*
+    ;
+
+revokeStatement
+    : REVOKE privelegeClause (',' privelegeClause)*
+      ON
+      privilegeObject=(TABLE | FUNCTION | PROCEDURE)?
+      privilegeLevel
+      FROM userName (',' userName)*                                 #detailRevoke
+    | REVOKE ALL PRIVILEGES? ',' GRANT OPTION
+      FROM userName (',' userName)*                                 #shortRevoke
+    | REVOKE (userName | uid) (',' (userName | uid))*
+      FROM (userName | uid) (',' (userName | uid))*                 #roleRevoke
+    ;
+
+revokeProxy
+    : REVOKE PROXY ON onUser=userName
+      FROM fromFirst=userName (',' fromOther+=userName)*
+    ;
+
+setPasswordStatement
+    : SET PASSWORD (FOR userName)?
+      '=' ( passwordFunctionClause | STRING_LITERAL)
+    ;
+
+// details
+
+userSpecification
+    : userName userPasswordOption
+    ;
+
+userAuthOption
+    : userName IDENTIFIED BY PASSWORD hashed=STRING_LITERAL         #hashAuthOption
+    | userName
+      IDENTIFIED BY STRING_LITERAL (RETAIN CURRENT PASSWORD)?       #stringAuthOption
+    | userName
+      IDENTIFIED WITH
+      authenticationRule                                            #moduleAuthOption
+    | userName                                                      #simpleAuthOption
+    ;
+
+authenticationRule
+    : authPlugin
+      ((BY | USING | AS) STRING_LITERAL)?                           #module
+    | authPlugin
+      USING passwordFunctionClause                                  #passwordModuleOption
+    ;
+
+tlsOption
+    : SSL
+    | X509
+    | CIPHER STRING_LITERAL
+    | ISSUER STRING_LITERAL
+    | SUBJECT STRING_LITERAL
+    ;
+
+userResourceOption
+    : MAX_QUERIES_PER_HOUR decimalLiteral
+    | MAX_UPDATES_PER_HOUR decimalLiteral
+    | MAX_CONNECTIONS_PER_HOUR decimalLiteral
+    | MAX_USER_CONNECTIONS decimalLiteral
+    ;
+
+userPasswordOption
+    : PASSWORD EXPIRE
+      (expireType=DEFAULT
+      | expireType=NEVER
+      | expireType=INTERVAL decimalLiteral DAY
+      )?
+    | PASSWORD HISTORY (DEFAULT | decimalLiteral)
+    | PASSWORD REUSE INTERVAL (DEFAULT | decimalLiteral DAY)
+    | PASSWORD REQUIRE CURRENT (OPTIONAL | DEFAULT)?
+    | FAILED_LOGIN_ATTEMPTS decimalLiteral
+    | PASSWORD_LOCK_TIME (decimalLiteral | UNBOUNDED)
+    ;
+
+userLockOption
+    : ACCOUNT lockType=(LOCK | UNLOCK)
+    ;
+
+privelegeClause
+    : privilege ( '(' uidList ')' )?
+    ;
+
+privilege
+    : ALL PRIVILEGES?
+    | ALTER ROUTINE?
+    | CREATE
+      (TEMPORARY TABLES | ROUTINE | VIEW | USER | TABLESPACE | ROLE)?
+    | DELETE | DROP (ROLE)? | EVENT | EXECUTE | FILE | GRANT OPTION
+    | INDEX | INSERT | LOCK TABLES | PROCESS | PROXY
+    | REFERENCES | RELOAD
+    | REPLICATION (CLIENT | SLAVE)
+    | SELECT
+    | SHOW (VIEW | DATABASES)
+    | SHUTDOWN | SUPER | TRIGGER | UPDATE | USAGE
+    | APPLICATION_PASSWORD_ADMIN | AUDIT_ADMIN | BACKUP_ADMIN | BINLOG_ADMIN | BINLOG_ENCRYPTION_ADMIN | CLONE_ADMIN
+    | CONNECTION_ADMIN | ENCRYPTION_KEY_ADMIN | FIREWALL_ADMIN | FIREWALL_USER | FLUSH_OPTIMIZER_COSTS
+    | FLUSH_STATUS | FLUSH_TABLES | FLUSH_USER_RESOURCES | GROUP_REPLICATION_ADMIN
+    | INNODB_REDO_LOG_ARCHIVE | INNODB_REDO_LOG_ENABLE | NDB_STORED_USER | PASSWORDLESS_USER_ADMIN | PERSIST_RO_VARIABLES_ADMIN | REPLICATION_APPLIER
+    | REPLICATION_SLAVE_ADMIN | RESOURCE_GROUP_ADMIN | RESOURCE_GROUP_USER | ROLE_ADMIN
+    | SERVICE_CONNECTION_ADMIN
+    | SESSION_VARIABLES_ADMIN | SET_USER_ID | SHOW_ROUTINE | SYSTEM_USER | SYSTEM_VARIABLES_ADMIN
+    | TABLE_ENCRYPTION_ADMIN | VERSION_TOKEN_ADMIN | XA_RECOVER_ADMIN
+    // MySQL on Amazon RDS
+    | LOAD FROM S3 | SELECT INTO S3 | INVOKE LAMBDA
+    ;
+
+privilegeLevel
+    : '*'                                                           #currentSchemaPriviLevel
+    | '*' '.' '*'                                                   #globalPrivLevel
+    | uid '.' '*'                                                   #definiteSchemaPrivLevel
+    | uid '.' uid                                                   #definiteFullTablePrivLevel
+    | uid dottedId                                                  #definiteFullTablePrivLevel2
+    | uid                                                           #definiteTablePrivLevel
+    ;
+
+renameUserClause
+    : fromFirst=userName TO toFirst=userName
+    ;
+
+//    Table maintenance statements
+
+analyzeTable
+    : ANALYZE actionOption=(NO_WRITE_TO_BINLOG | LOCAL)?
+       (TABLE | TABLES) tables
+       ( UPDATE HISTOGRAM ON fullColumnName (',' fullColumnName)* (WITH decimalLiteral BUCKETS)? )?
+       ( DROP HISTOGRAM ON fullColumnName (',' fullColumnName)* )?
+    ;
+
+checkTable
+    : CHECK TABLE tables checkTableOption*
+    ;
+
+checksumTable
+    : CHECKSUM TABLE tables actionOption=(QUICK | EXTENDED)?
+    ;
+
+optimizeTable
+    : OPTIMIZE actionOption=(NO_WRITE_TO_BINLOG | LOCAL)?
+      (TABLE | TABLES) tables
+    ;
+
+repairTable
+    : REPAIR actionOption=(NO_WRITE_TO_BINLOG | LOCAL)?
+      TABLE tables
+      QUICK? EXTENDED? USE_FRM?
+    ;
+
+// details
+
+checkTableOption
+    : FOR UPGRADE | QUICK | FAST | MEDIUM | EXTENDED | CHANGED
+    ;
+
+
+//    Plugin and udf statements
+
+createUdfunction
+    : CREATE AGGREGATE? FUNCTION ifNotExists? uid
+      RETURNS returnType=(STRING | INTEGER | REAL | DECIMAL)
+      SONAME STRING_LITERAL
+    ;
+
+installPlugin
+    : INSTALL PLUGIN uid SONAME STRING_LITERAL
+    ;
+
+uninstallPlugin
+    : UNINSTALL PLUGIN uid
+    ;
+
+
+//    Set and show statements
+
+setStatement
+    : SET variableClause ('=' | ':=') (expression | ON)
+      (',' variableClause ('=' | ':=') (expression | ON))*                      #setVariable
+    | SET charSet (charsetName | DEFAULT)          #setCharset
+    | SET NAMES
+        (charsetName (COLLATE collationName)? | DEFAULT)                        #setNames
+    | setPasswordStatement                                                      #setPassword
+    | setTransactionStatement                                                   #setTransaction
+    | setAutocommitStatement                                                    #setAutocommit
+    | SET fullId ('=' | ':=') expression
+      (',' fullId ('=' | ':=') expression)*                                     #setNewValueInsideTrigger
+    ;
+
+showStatement
+    : SHOW logFormat=(BINARY | MASTER) LOGS                         #showMasterLogs
+    | SHOW logFormat=(BINLOG | RELAYLOG)
+      EVENTS (IN filename=STRING_LITERAL)?
+        (FROM fromPosition=decimalLiteral)?
+        (LIMIT
+          (offset=decimalLiteral ',')?
+          rowCount=decimalLiteral
+        )?                                                          #showLogEvents
+    | SHOW showCommonEntity showFilter?                             #showObjectFilter
+    | SHOW FULL? columnsFormat=(COLUMNS | FIELDS)
+      tableFormat=(FROM | IN) tableName
+        (schemaFormat=(FROM | IN) uid)? showFilter?                 #showColumns
+    | SHOW CREATE schemaFormat=(DATABASE | SCHEMA)
+      ifNotExists? uid                                              #showCreateDb
+    | SHOW CREATE
+        namedEntity=(
+          EVENT | FUNCTION | PROCEDURE
+          | TABLE | TRIGGER | VIEW
+        )
+        fullId                                                      #showCreateFullIdObject
+    | SHOW CREATE USER userName                                     #showCreateUser
+    | SHOW ENGINE engineName engineOption=(STATUS | MUTEX)          #showEngine
+    | SHOW showGlobalInfoClause                                     #showGlobalInfo
+    | SHOW errorFormat=(ERRORS | WARNINGS)
+        (LIMIT
+          (offset=decimalLiteral ',')?
+          rowCount=decimalLiteral
+        )?                                                          #showErrors
+    | SHOW COUNT '(' '*' ')' errorFormat=(ERRORS | WARNINGS)        #showCountErrors
+    | SHOW showSchemaEntity
+        (schemaFormat=(FROM | IN) uid)? showFilter?                 #showSchemaFilter
+    | SHOW routine=(FUNCTION | PROCEDURE) CODE fullId               #showRoutine
+    | SHOW GRANTS (FOR userName)?                                   #showGrants
+    | SHOW indexFormat=(INDEX | INDEXES | KEYS)
+      tableFormat=(FROM | IN) tableName
+        (schemaFormat=(FROM | IN) uid)? (WHERE expression)?         #showIndexes
+    | SHOW OPEN TABLES ( schemaFormat=(FROM | IN) uid)?
+      showFilter?                                                   #showOpenTables
+    | SHOW PROFILE showProfileType (',' showProfileType)*
+        (FOR QUERY queryCount=decimalLiteral)?
+        (LIMIT
+          (offset=decimalLiteral ',')?
+          rowCount=decimalLiteral
+        )                                                           #showProfile
+    | SHOW SLAVE STATUS (FOR CHANNEL STRING_LITERAL)?               #showSlaveStatus
+    ;
+
+// details
+
+variableClause
+    : LOCAL_ID | GLOBAL_ID | ( ('@' '@')? (GLOBAL | SESSION | LOCAL)  )? uid
+    ;
+
+showCommonEntity
+    : CHARACTER SET | COLLATION | DATABASES | SCHEMAS
+    | FUNCTION STATUS | PROCEDURE STATUS
+    | (GLOBAL | SESSION)? (STATUS | VARIABLES)
+    ;
+
+showFilter
+    : LIKE STRING_LITERAL
+    | WHERE expression
+    ;
+
+showGlobalInfoClause
+    : STORAGE? ENGINES | MASTER STATUS | PLUGINS
+    | PRIVILEGES | FULL? PROCESSLIST | PROFILES
+    | SLAVE HOSTS | AUTHORS | CONTRIBUTORS
+    ;
+
+showSchemaEntity
+    : EVENTS | TABLE STATUS | FULL? TABLES | TRIGGERS
+    ;
+
+showProfileType
+    : ALL | BLOCK IO | CONTEXT SWITCHES | CPU | IPC | MEMORY
+    | PAGE FAULTS | SOURCE | SWAPS
+    ;
+
+
+//    Other administrative statements
+
+binlogStatement
+    : BINLOG STRING_LITERAL
+    ;
+
+cacheIndexStatement
+    : CACHE INDEX tableIndexes (',' tableIndexes)*
+      ( PARTITION '(' (uidList | ALL) ')' )?
+      IN schema=uid
+    ;
+
+flushStatement
+    : FLUSH flushFormat=(NO_WRITE_TO_BINLOG | LOCAL)?
+      flushOption (',' flushOption)*
+    ;
+
+killStatement
+    : KILL connectionFormat=(CONNECTION | QUERY)? expression
+    ;
+
+loadIndexIntoCache
+    : LOAD INDEX INTO CACHE
+      loadedTableIndexes (',' loadedTableIndexes)*
+    ;
+
+// remark reset (maser | slave) describe in replication's
+//  statements section
+resetStatement
+    : RESET QUERY CACHE
+    ;
+
+shutdownStatement
+    : SHUTDOWN
+    ;
+
+// details
+
+tableIndexes
+    : tableName ( indexFormat=(INDEX | KEY)? '(' uidList ')' )?
+    ;
+
+flushOption
+    : (
+        DES_KEY_FILE | HOSTS
+        | (
+            BINARY | ENGINE | ERROR | GENERAL | RELAY | SLOW
+          )? LOGS
+        | OPTIMIZER_COSTS | PRIVILEGES | QUERY CACHE | STATUS
+        | USER_RESOURCES | TABLES (WITH READ LOCK)?
+       )                                                            #simpleFlushOption
+    | RELAY LOGS channelOption?                                     #channelFlushOption
+    | (TABLE | TABLES) tables? flushTableOption?                    #tableFlushOption
+    ;
+
+flushTableOption
+    : WITH READ LOCK
+    | FOR EXPORT
+    ;
+
+loadedTableIndexes
+    : tableName
+      ( PARTITION '(' (partitionList=uidList | ALL) ')' )?
+      ( indexFormat=(INDEX | KEY)? '(' indexList=uidList ')' )?
+      (IGNORE LEAVES)?
+    ;
+
+
+// Utility Statements
+
+
+simpleDescribeStatement
+    : command=(EXPLAIN | DESCRIBE | DESC) tableName
+      (column=uid | pattern=STRING_LITERAL)?
+    ;
+
+fullDescribeStatement
+    : command=(EXPLAIN | DESCRIBE | DESC)
+      (
+        formatType=(EXTENDED | PARTITIONS | FORMAT )
+        '='
+        formatValue=(TRADITIONAL | JSON)
+      )?
+      describeObjectClause
+    ;
+
+helpStatement
+    : HELP STRING_LITERAL
+    ;
+
+useStatement
+    : USE uid
+    ;
+
+signalStatement
+    : SIGNAL ( ( SQLSTATE VALUE? stringLiteral ) | ID | REVERSE_QUOTE_ID )
+        ( SET signalConditionInformation ( ',' signalConditionInformation)* )?
+    ;
+
+resignalStatement
+    : RESIGNAL ( ( SQLSTATE VALUE? stringLiteral ) | ID | REVERSE_QUOTE_ID )?
+        ( SET signalConditionInformation ( ',' signalConditionInformation)* )?
+    ;
+
+signalConditionInformation
+    : ( CLASS_ORIGIN
+          | SUBCLASS_ORIGIN
+          | MESSAGE_TEXT
+          | MYSQL_ERRNO
+          | CONSTRAINT_CATALOG
+          | CONSTRAINT_SCHEMA
+          | CONSTRAINT_NAME
+          | CATALOG_NAME
+          | SCHEMA_NAME
+          | TABLE_NAME
+          | COLUMN_NAME
+          | CURSOR_NAME
+        ) '=' ( stringLiteral | DECIMAL_LITERAL | mysqlVariable | simpleId )
+    ;
+
+withStatement
+  : WITH RECURSIVE? commonTableExpressions (',' commonTableExpressions)*
+  ;
+
+diagnosticsStatement
+    : GET ( CURRENT | STACKED )? DIAGNOSTICS (
+          ( variableClause '=' ( NUMBER | ROW_COUNT ) ( ',' variableClause '=' ( NUMBER | ROW_COUNT ) )* )
+        | ( CONDITION  ( decimalLiteral | variableClause ) variableClause '=' diagnosticsConditionInformationName ( ',' variableClause '=' diagnosticsConditionInformationName )* )
+      )
+    ;
+
+diagnosticsConditionInformationName
+    : CLASS_ORIGIN
+    | SUBCLASS_ORIGIN
+    | RETURNED_SQLSTATE
+    | MESSAGE_TEXT
+    | MYSQL_ERRNO
+    | CONSTRAINT_CATALOG
+    | CONSTRAINT_SCHEMA
+    | CONSTRAINT_NAME
+    | CATALOG_NAME
+    | SCHEMA_NAME
+    | TABLE_NAME
+    | COLUMN_NAME
+    | CURSOR_NAME
+    ;
+
+// details
+
+describeObjectClause
+    : (
+        selectStatement | deleteStatement | insertStatement
+        | replaceStatement | updateStatement
+      )                                                             #describeStatements
+    | FOR CONNECTION uid                                            #describeConnection
+    ;
+
+
+// Common Clauses
+
+//    DB Objects
+
+fullId
+    : uid (DOT_ID | '.' uid)?
+    ;
+
+tableName
+    : fullId
+    ;
+
+roleName
+    : userName | uid
+    ;
+
+fullColumnName
+    : uid (dottedId dottedId? )?
+    | .? dottedId dottedId?
+    ;
+
+indexColumnName
+    : ((uid | STRING_LITERAL) ('(' decimalLiteral ')')? | expression) sortType=(ASC | DESC)?
+    ;
+
+userName
+    : STRING_USER_NAME | ID | STRING_LITERAL | ADMIN | keywordsCanBeId;
+
+mysqlVariable
+    : LOCAL_ID
+    | GLOBAL_ID
+    ;
+
+charsetName
+    : BINARY
+    | charsetNameBase
+    | STRING_LITERAL
+    | CHARSET_REVERSE_QOUTE_STRING
+    ;
+
+collationName
+    : uid | STRING_LITERAL;
+
+engineName
+    : ARCHIVE | BLACKHOLE | CSV | FEDERATED | INNODB | MEMORY
+    | MRG_MYISAM | MYISAM | NDB | NDBCLUSTER | PERFORMANCE_SCHEMA
+    | TOKUDB
+    | ID
+    | STRING_LITERAL | REVERSE_QUOTE_ID
+    | CONNECT
+    ;
+
+uuidSet
+    : decimalLiteral '-' decimalLiteral '-' decimalLiteral
+      '-' decimalLiteral '-' decimalLiteral
+      (':' decimalLiteral '-' decimalLiteral)+
+    ;
+
+xid
+    : globalTableUid=xuidStringId
+      (
+        ',' qualifier=xuidStringId
+        (',' idFormat=decimalLiteral)?
+      )?
+    ;
+
+xuidStringId
+    : STRING_LITERAL
+    | BIT_STRING
+    | HEXADECIMAL_LITERAL+
+    ;
+
+authPlugin
+    : uid | STRING_LITERAL
+    ;
+
+uid
+    : simpleId
+    //| DOUBLE_QUOTE_ID
+    | REVERSE_QUOTE_ID
+    | CHARSET_REVERSE_QOUTE_STRING
+    ;
+
+simpleId
+    : ID
+    | charsetNameBase
+    | transactionLevelBase
+    | engineName
+    | privilegesBase
+    | intervalTypeBase
+    | dataTypeBase
+    | keywordsCanBeId
+    | scalarFunctionName
+    ;
+
+dottedId
+    : DOT_ID
+    | '.' uid
+    ;
+
+
+//    Literals
+
+decimalLiteral
+    : DECIMAL_LITERAL | ZERO_DECIMAL | ONE_DECIMAL | TWO_DECIMAL | REAL_LITERAL
+    ;
+
+fileSizeLiteral
+    : FILESIZE_LITERAL | decimalLiteral;
+
+stringLiteral
+    : (
+        STRING_CHARSET_NAME? STRING_LITERAL
+        | START_NATIONAL_STRING_LITERAL
+      ) STRING_LITERAL+
+    | (
+        STRING_CHARSET_NAME? STRING_LITERAL
+        | START_NATIONAL_STRING_LITERAL
+      ) (COLLATE collationName)?
+    ;
+
+booleanLiteral
+    : TRUE | FALSE;
+
+hexadecimalLiteral
+    : STRING_CHARSET_NAME? HEXADECIMAL_LITERAL;
+
+nullNotnull
+    : NOT? (NULL_LITERAL | NULL_SPEC_LITERAL)
+    ;
+
+constant
+    : stringLiteral | decimalLiteral
+    | '-' decimalLiteral
+    | hexadecimalLiteral | booleanLiteral
+    | REAL_LITERAL | BIT_STRING
+    | NOT? nullLiteral=(NULL_LITERAL | NULL_SPEC_LITERAL)
+    ;
+
+
+//    Data Types
+
+dataType
+    : typeName=(
+      CHAR | CHARACTER | VARCHAR | TINYTEXT | TEXT | MEDIUMTEXT | LONGTEXT
+       | NCHAR | NVARCHAR | LONG
+      )
+      VARYING?
+      lengthOneDimension? BINARY?
+      (charSet charsetName)?
+      (COLLATE collationName | BINARY)?                             #stringDataType
+    | NATIONAL typeName=(CHAR | CHARACTER) VARYING
+      lengthOneDimension? BINARY?                                   #nationalVaryingStringDataType
+    | NATIONAL typeName=(VARCHAR | CHARACTER | CHAR)
+      lengthOneDimension? BINARY?                                   #nationalStringDataType
+    | NCHAR typeName=VARCHAR
+      lengthOneDimension? BINARY?                                   #nationalStringDataType
+    | typeName=(
+        TINYINT | SMALLINT | MEDIUMINT | INT | INTEGER | BIGINT
+        | MIDDLEINT | INT1 | INT2 | INT3 | INT4 | INT8
+      )
+      lengthOneDimension? (SIGNED | UNSIGNED | ZEROFILL)*           #dimensionDataType
+    | typeName=REAL
+      lengthTwoDimension? (SIGNED | UNSIGNED | ZEROFILL)*           #dimensionDataType
+    | typeName=DOUBLE PRECISION?
+      lengthTwoDimension? (SIGNED | UNSIGNED | ZEROFILL)*           #dimensionDataType
+    | typeName=(DECIMAL | DEC | FIXED | NUMERIC | FLOAT | FLOAT4 | FLOAT8)
+      lengthTwoOptionalDimension? (SIGNED | UNSIGNED | ZEROFILL)*   #dimensionDataType
+    | typeName=(
+        DATE | TINYBLOB | MEDIUMBLOB | LONGBLOB
+        | BOOL | BOOLEAN | SERIAL
+      )                                                             #simpleDataType
+    | typeName=(
+        BIT | TIME | TIMESTAMP | DATETIME | BINARY
+        | VARBINARY | BLOB | YEAR
+      )
+      lengthOneDimension?                                           #dimensionDataType
+    | typeName=(ENUM | SET)
+      collectionOptions BINARY?
+      (charSet charsetName)?                                        #collectionDataType
+    | typeName=(
+        GEOMETRYCOLLECTION | GEOMCOLLECTION | LINESTRING | MULTILINESTRING
+        | MULTIPOINT | MULTIPOLYGON | POINT | POLYGON | JSON | GEOMETRY
+      )  (SRID decimalLiteral)?                                    #spatialDataType
+    | typeName=LONG VARCHAR?
+      BINARY?
+      (charSet charsetName)?
+      (COLLATE collationName)?                                      #longVarcharDataType    // LONG VARCHAR is the same as LONG
+    | LONG VARBINARY                                                #longVarbinaryDataType
+    ;
+
+collectionOptions
+    : '(' STRING_LITERAL (',' STRING_LITERAL)* ')'
+    ;
+
+convertedDataType
+    :
+    (
+      typeName=(BINARY| NCHAR) lengthOneDimension?
+      | typeName=CHAR lengthOneDimension? (charSet charsetName)?
+      | typeName=(DATE | DATETIME | TIME | JSON | INT | INTEGER)
+      | typeName=DECIMAL lengthTwoOptionalDimension?
+      | (SIGNED | UNSIGNED) INTEGER?
+    ) ARRAY?
+    ;
+
+lengthOneDimension
+    : '(' decimalLiteral ')'
+    ;
+
+lengthTwoDimension
+    : '(' decimalLiteral ',' decimalLiteral ')'
+    ;
+
+lengthTwoOptionalDimension
+    : '(' decimalLiteral (',' decimalLiteral)? ')'
+    ;
+
+
+//    Common Lists
+
+uidList
+    : uid (',' uid)*
+    ;
+
+fullColumnNameList
+    : fullColumnName (',' fullColumnName)*
+    ;
+
+tables
+    : tableName (',' tableName)*
+    ;
+
+indexColumnNames
+    : '(' indexColumnName (',' indexColumnName)* ')'
+    ;
+
+expressions
+    : expression (',' expression)*
+    ;
+
+expressionsWithDefaults
+    : expressionOrDefault (',' expressionOrDefault)*
+    ;
+
+constants
+    : constant (',' constant)*
+    ;
+
+simpleStrings
+    : STRING_LITERAL (',' STRING_LITERAL)*
+    ;
+
+userVariables
+    : LOCAL_ID (',' LOCAL_ID)*
+    ;
+
+
+//    Common Expressons
+
+defaultValue
+    : NULL_LITERAL
+    | CAST '(' expression AS convertedDataType ')'
+    | unaryOperator? constant
+    | currentTimestamp (ON UPDATE currentTimestamp)?
+    | '(' expression ')'
+    | '(' fullId ')'
+    ;
+
+currentTimestamp
+    :
+    (
+      (CURRENT_TIMESTAMP | LOCALTIME | LOCALTIMESTAMP)
+      ('(' decimalLiteral? ')')?
+      | NOW '(' decimalLiteral? ')'
+    )
+    ;
+
+expressionOrDefault
+    : expression | DEFAULT
+    ;
+
+ifExists
+    : IF EXISTS
+    ;
+
+
+ifNotExists
+    : IF NOT EXISTS
+    ;
+
+orReplace
+    : OR REPLACE
+    ;
+
+waitNowaitClause
+    : WAIT decimalLiteral
+    | NOWAIT
+    ;
+
+//    Functions
+
+functionCall
+    : specificFunction                                              #specificFunctionCall
+    | aggregateWindowedFunction                                     #aggregateFunctionCall
+    | nonAggregateWindowedFunction                                  #nonAggregateFunctionCall
+    | scalarFunctionName '(' functionArgs? ')'                      #scalarFunctionCall
+    | fullId '(' functionArgs? ')'                                  #udfFunctionCall
+    | passwordFunctionClause                                        #passwordFunctionCall
+    ;
+
+specificFunction
+    : (
+      CURRENT_DATE | CURRENT_TIME | CURRENT_TIMESTAMP
+      | CURRENT_USER | LOCALTIME | UTC_TIMESTAMP | SCHEMA
+      ) ('(' ')')?                                                  #simpleFunctionCall
+    | CONVERT '(' expression separator=',' convertedDataType ')'    #dataTypeFunctionCall
+    | CONVERT '(' expression USING charsetName ')'                  #dataTypeFunctionCall
+    | CAST '(' expression AS convertedDataType ')'                  #dataTypeFunctionCall
+    | VALUES '(' fullColumnName ')'                                 #valuesFunctionCall
+    | CASE expression caseFuncAlternative+
+      (ELSE elseArg=functionArg)? END                               #caseExpressionFunctionCall
+    | CASE caseFuncAlternative+
+      (ELSE elseArg=functionArg)? END                               #caseFunctionCall
+    | CHAR '(' functionArgs  (USING charsetName)? ')'               #charFunctionCall
+    | POSITION
+      '('
+          (
+            positionString=stringLiteral
+            | positionExpression=expression
+          )
+          IN
+          (
+            inString=stringLiteral
+            | inExpression=expression
+          )
+      ')'                                                           #positionFunctionCall
+    | (SUBSTR | SUBSTRING)
+      '('
+        (
+          sourceString=stringLiteral
+          | sourceExpression=expression
+        ) FROM
+        (
+          fromDecimal=decimalLiteral
+          | fromExpression=expression
+        )
+        (
+          FOR
+          (
+            forDecimal=decimalLiteral
+            | forExpression=expression
+          )
+        )?
+      ')'                                                           #substrFunctionCall
+    | TRIM
+      '('
+        positioinForm=(BOTH | LEADING | TRAILING)
+        (
+          sourceString=stringLiteral
+          | sourceExpression=expression
+        )?
+        FROM
+        (
+          fromString=stringLiteral
+          | fromExpression=expression
+        )
+      ')'                                                           #trimFunctionCall
+    | TRIM
+      '('
+        (
+          sourceString=stringLiteral
+          | sourceExpression=expression
+        )
+        FROM
+        (
+          fromString=stringLiteral
+          | fromExpression=expression
+        )
+      ')'                                                           #trimFunctionCall
+    | WEIGHT_STRING
+      '('
+        (stringLiteral | expression)
+        (AS stringFormat=(CHAR | BINARY)
+        '(' decimalLiteral ')' )?  levelsInWeightString?
+      ')'                                                           #weightFunctionCall
+    | EXTRACT
+      '('
+        intervalType
+        FROM
+        (
+          sourceString=stringLiteral
+          | sourceExpression=expression
+        )
+      ')'                                                           #extractFunctionCall
+    | GET_FORMAT
+      '('
+        datetimeFormat=(DATE | TIME | DATETIME)
+        ',' stringLiteral
+      ')'                                                           #getFormatFunctionCall
+    | JSON_VALUE
+      '(' expression
+       ',' expression
+         (RETURNING convertedDataType)?
+         jsonOnEmpty?
+         jsonOnError?
+       ')'                                                          #jsonValueFunctionCall
+    ;
+
+caseFuncAlternative
+    : WHEN condition=functionArg
+      THEN consequent=functionArg
+    ;
+
+levelsInWeightString
+    : LEVEL levelInWeightListElement
+      (',' levelInWeightListElement)*                               #levelWeightList
+    | LEVEL
+      firstLevel=decimalLiteral '-' lastLevel=decimalLiteral        #levelWeightRange
+    ;
+
+levelInWeightListElement
+    : decimalLiteral orderType=(ASC | DESC | REVERSE)?
+    ;
+
+aggregateWindowedFunction
+    : (AVG | MAX | MIN | SUM)
+      '(' aggregator=(ALL | DISTINCT)? functionArg ')' overClause?
+    | COUNT '(' (starArg='*' | aggregator=ALL? functionArg | aggregator=DISTINCT functionArgs) ')' overClause?
+    | (
+        BIT_AND | BIT_OR | BIT_XOR | STD | STDDEV | STDDEV_POP
+        | STDDEV_SAMP | VAR_POP | VAR_SAMP | VARIANCE
+      ) '(' aggregator=ALL? functionArg ')' overClause?
+    | GROUP_CONCAT '('
+        aggregator=DISTINCT? functionArgs
+        (ORDER BY
+          orderByExpression (',' orderByExpression)*
+        )? (SEPARATOR separator=STRING_LITERAL)?
+      ')'
+    ;
+
+nonAggregateWindowedFunction
+    : (LAG | LEAD) '(' expression (',' decimalLiteral)? (',' decimalLiteral)? ')' overClause
+    | (FIRST_VALUE | LAST_VALUE) '(' expression ')' overClause
+    | (CUME_DIST | DENSE_RANK | PERCENT_RANK | RANK | ROW_NUMBER) '('')' overClause
+    | NTH_VALUE '(' expression ',' decimalLiteral ')' overClause
+    | NTILE '(' decimalLiteral ')' overClause
+    ;
+
+overClause
+    : OVER ('(' windowSpec ')' | windowName)
+    ;
+
+windowSpec
+    : windowName? partitionClause? orderByClause? frameClause?
+    ;
+
+windowName
+    : uid
+    ;
+
+frameClause
+    : frameUnits frameExtent
+    ;
+
+frameUnits
+    : ROWS
+    | RANGE
+    ;
+
+frameExtent
+    : frameRange
+    | frameBetween
+    ;
+
+frameBetween
+    : BETWEEN frameRange AND frameRange
+    ;
+
+frameRange
+    : CURRENT ROW
+    | UNBOUNDED (PRECEDING | FOLLOWING)
+    | expression (PRECEDING | FOLLOWING)
+    ;
+
+partitionClause
+    : PARTITION BY expression (',' expression)*
+    ;
+
+scalarFunctionName
+    : functionNameBase
+    | ASCII | CURDATE | CURRENT_DATE | CURRENT_TIME
+    | CURRENT_TIMESTAMP | CURTIME | DATE_ADD | DATE_SUB
+    | IF | INSERT | LOCALTIME | LOCALTIMESTAMP | MID | NOW
+    | REPLACE | SUBSTR | SUBSTRING | SYSDATE | TRIM
+    | UTC_DATE | UTC_TIME | UTC_TIMESTAMP
+    ;
+
+passwordFunctionClause
+    : functionName=(PASSWORD | OLD_PASSWORD) '(' functionArg ')'
+    ;
+
+functionArgs
+    : (constant | fullColumnName | functionCall | expression)
+    (
+      ','
+      (constant | fullColumnName | functionCall | expression)
+    )*
+    ;
+
+functionArg
+    : constant | fullColumnName | functionCall | expression
+    ;
+
+
+//    Expressions, predicates
+
+// Simplified approach for expression
+expression
+    : notOperator=(NOT | '!') expression                            #notExpression
+    | expression logicalOperator expression                         #logicalExpression
+    | predicate IS NOT? testValue=(TRUE | FALSE | UNKNOWN)          #isExpression
+    | predicate                                                     #predicateExpression
+    ;
+
+predicate
+    : predicate NOT? IN '(' (selectStatement | expressions) ')'     #inPredicate
+    | predicate IS nullNotnull                                      #isNullPredicate
+    | left=predicate comparisonOperator right=predicate             #binaryComparisonPredicate
+    | predicate comparisonOperator
+      quantifier=(ALL | ANY | SOME) '(' selectStatement ')'         #subqueryComparisonPredicate
+    | predicate NOT? BETWEEN predicate AND predicate                #betweenPredicate
+    | predicate SOUNDS LIKE predicate                               #soundsLikePredicate
+    | predicate NOT? LIKE predicate (ESCAPE STRING_LITERAL)?        #likePredicate
+    | predicate NOT? regex=(REGEXP | RLIKE) predicate               #regexpPredicate
+    | (LOCAL_ID VAR_ASSIGN)? expressionAtom                         #expressionAtomPredicate
+    | predicate MEMBER OF '(' predicate ')'                         #jsonMemberOfPredicate
+    ;
+
+
+// Add in ASTVisitor nullNotnull in constant
+expressionAtom
+    : constant                                                      #constantExpressionAtom
+    | fullColumnName                                                #fullColumnNameExpressionAtom
+    | functionCall                                                  #functionCallExpressionAtom
+    | expressionAtom COLLATE collationName                          #collateExpressionAtom
+    | mysqlVariable                                                 #mysqlVariableExpressionAtom
+    | unaryOperator expressionAtom                                  #unaryExpressionAtom
+    | BINARY expressionAtom                                         #binaryExpressionAtom
+    | '(' expression (',' expression)* ')'                          #nestedExpressionAtom
+    | ROW '(' expression (',' expression)+ ')'                      #nestedRowExpressionAtom
+    | EXISTS '(' selectStatement ')'                                #existsExpressionAtom
+    | '(' selectStatement ')'                                       #subqueryExpressionAtom
+    | INTERVAL expression intervalType                              #intervalExpressionAtom
+    | left=expressionAtom bitOperator right=expressionAtom          #bitExpressionAtom
+    | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
+    | left=expressionAtom jsonOperator right=expressionAtom         #jsonExpressionAtom
+    ;
+
+unaryOperator
+    : '!' | '~' | '+' | '-' | NOT
+    ;
+
+comparisonOperator
+    : '=' | '>' | '<' | '<' '=' | '>' '='
+    | '<' '>' | '!' '=' | '<' '=' '>'
+    ;
+
+logicalOperator
+    : AND | '&' '&' | XOR | OR | '|' '|'
+    ;
+
+bitOperator
+    : '<' '<' | '>' '>' | '&' | '^' | '|'
+    ;
+
+mathOperator
+    : '*' | '/' | '%' | DIV | MOD | '+' | '-'
+    ;
+
+jsonOperator
+    : '-' '>' | '-' '>' '>'
+    ;
+
+//    Simple id sets
+//     (that keyword, which can be id)
+
+charsetNameBase
+    : ARMSCII8 | ASCII | BIG5 | BINARY | CP1250 | CP1251 | CP1256 | CP1257
+    | CP850 | CP852 | CP866 | CP932 | DEC8 | EUCJPMS | EUCKR
+    | GB18030 | GB2312 | GBK | GEOSTD8 | GREEK | HEBREW | HP8 | KEYBCS2
+    | KOI8R | KOI8U | LATIN1 | LATIN2 | LATIN5 | LATIN7 | MACCE
+    | MACROMAN | SJIS | SWE7 | TIS620 | UCS2 | UJIS | UTF16
+    | UTF16LE | UTF32 | UTF8 | UTF8MB3 | UTF8MB4
+    ;
+
+transactionLevelBase
+    : REPEATABLE | COMMITTED | UNCOMMITTED | SERIALIZABLE
+    ;
+
+privilegesBase
+    : TABLES | ROUTINE | EXECUTE | FILE | PROCESS
+    | RELOAD | SHUTDOWN | SUPER | PRIVILEGES
+    ;
+
+intervalTypeBase
+    : QUARTER | MONTH | DAY | HOUR
+    | MINUTE | WEEK | SECOND | MICROSECOND
+    ;
+
+dataTypeBase
+    : DATE | TIME | TIMESTAMP | DATETIME | YEAR | ENUM | TEXT
+    ;
+
+keywordsCanBeId
+    : ACCOUNT | ACTION | ADMIN | AFTER | AGGREGATE | ALGORITHM | ANY
+    | AT | AUDIT_ADMIN | AUTHORS | AUTOCOMMIT | AUTOEXTEND_SIZE
+    | AUTO_INCREMENT | AVG | AVG_ROW_LENGTH | ATTRIBUTE | BACKUP_ADMIN | BEGIN | BINLOG | BINLOG_ADMIN | BINLOG_ENCRYPTION_ADMIN | BIT | BIT_AND | BIT_OR | BIT_XOR
+    | BLOCK | BOOL | BOOLEAN | BTREE | BUCKETS | CACHE | CASCADED | CHAIN | CHANGED
+    | CHANNEL | CHECKSUM | PAGE_CHECKSUM | CATALOG_NAME | CIPHER
+    | CLASS_ORIGIN | CLIENT | CLONE_ADMIN | CLOSE | CLUSTERING | COALESCE | CODE
+    | COLUMNS | COLUMN_FORMAT | COLUMN_NAME | COMMENT | COMMIT | COMPACT
+    | COMPLETION | COMPRESSED | COMPRESSION | CONCURRENT | CONDITION | CONNECT
+    | CONNECTION | CONNECTION_ADMIN | CONSISTENT | CONSTRAINT_CATALOG | CONSTRAINT_NAME
+    | CONSTRAINT_SCHEMA | CONTAINS | CONTEXT
+    | CONTRIBUTORS | COPY | COUNT | CPU | CURRENT | CURRENT_USER | CURSOR_NAME
+    | DATA | DATAFILE | DEALLOCATE
+    | DEFAULT | DEFAULT_AUTH | DEFINER | DELAY_KEY_WRITE | DES_KEY_FILE | DIAGNOSTICS | DIRECTORY
+    | DISABLE | DISCARD | DISK | DO | DUMPFILE | DUPLICATE
+    | DYNAMIC | EMPTY | ENABLE | ENCRYPTION | ENCRYPTION_KEY_ADMIN | END | ENDS | ENGINE | ENGINE_ATTRIBUTE | ENGINES | ENFORCED
+    | ERROR | ERRORS | ESCAPE | EUR | EVEN | EVENT | EVENTS | EVERY | EXCEPT
+    | EXCHANGE | EXCLUSIVE | EXPIRE | EXPORT | EXTENDED | EXTENT_SIZE | FAILED_LOGIN_ATTEMPTS | FAST | FAULTS
+    | FIELDS | FILE_BLOCK_SIZE | FILTER | FIREWALL_ADMIN | FIREWALL_USER | FIRST | FIXED | FLUSH
+    | FOLLOWS | FOUND | FULL | FUNCTION | GENERAL | GLOBAL | GRANTS | GROUP | GROUP_CONCAT
+    | GROUP_REPLICATION | GROUP_REPLICATION_ADMIN | HANDLER | HASH | HELP | HISTORY | HOST | HOSTS | IDENTIFIED
+    | IGNORED | IGNORE_SERVER_IDS | IMPORT | INDEXES | INITIAL_SIZE | INNODB_REDO_LOG_ARCHIVE
+    | INPLACE | INSERT_METHOD | INSTALL | INSTANCE | INSTANT | INTERNAL | INVOKE | INVOKER | IO
+    | IO_THREAD | IPC | ISO | ISOLATION | ISSUER | JIS | JSON | KEY_BLOCK_SIZE
+    | LAMBDA | LANGUAGE | LAST | LATERAL | LEAVES | LESS | LEVEL | LIST | LOCAL
+    | LOGFILE | LOGS | MASTER | MASTER_AUTO_POSITION
+    | MASTER_CONNECT_RETRY | MASTER_DELAY
+    | MASTER_HEARTBEAT_PERIOD | MASTER_HOST | MASTER_LOG_FILE
+    | MASTER_LOG_POS | MASTER_PASSWORD | MASTER_PORT
+    | MASTER_RETRY_COUNT | MASTER_SSL | MASTER_SSL_CA
+    | MASTER_SSL_CAPATH | MASTER_SSL_CERT | MASTER_SSL_CIPHER
+    | MASTER_SSL_CRL | MASTER_SSL_CRLPATH | MASTER_SSL_KEY
+    | MASTER_TLS_VERSION | MASTER_USER
+    | MAX_CONNECTIONS_PER_HOUR | MAX_QUERIES_PER_HOUR
+    | MAX | MAX_ROWS | MAX_SIZE | MAX_UPDATES_PER_HOUR
+    | MAX_USER_CONNECTIONS | MEDIUM | MEMBER | MEMORY | MERGE | MESSAGE_TEXT
+    | MID | MIGRATE
+    | MIN | MIN_ROWS | MODE | MODIFY | MUTEX | MYSQL | MYSQL_ERRNO | NAME | NAMES
+    | NCHAR | NDB_STORED_USER | NESTED | NEVER | NEXT | NO | NOCOPY | NODEGROUP | NONE | NOWAIT | NUMBER | ODBC | OFFLINE | OFFSET
+    | OF | OJ | OLD_PASSWORD | ONE | ONLINE | ONLY | OPEN | OPTIMIZER_COSTS
+    | OPTIONAL | OPTIONS | ORDER | ORDINALITY | OWNER | PACK_KEYS | PAGE | PARSER | PARTIAL
+    | PARTITIONING | PARTITIONS | PASSWORD | PASSWORDLESS_USER_ADMIN | PASSWORD_LOCK_TIME | PATH | PERSIST_RO_VARIABLES_ADMIN | PHASE | PLUGINS
+    | PLUGIN_DIR | PLUGIN | PORT | PRECEDES | PREPARE | PRESERVE | PREV | PRIMARY
+    | PROCESSLIST | PROFILE | PROFILES | PROXY | QUERY | QUICK
+    | REBUILD | RECOVER | RECURSIVE | REDO_BUFFER_SIZE | REDUNDANT
+    | RELAY | RELAYLOG | RELAY_LOG_FILE | RELAY_LOG_POS | REMOVE
+    | REORGANIZE | REPAIR | REPLICATE_DO_DB | REPLICATE_DO_TABLE
+    | REPLICATE_IGNORE_DB | REPLICATE_IGNORE_TABLE
+    | REPLICATE_REWRITE_DB | REPLICATE_WILD_DO_TABLE
+    | REPLICATE_WILD_IGNORE_TABLE | REPLICATION | REPLICATION_APPLIER | REPLICATION_SLAVE_ADMIN | RESET
+    | RESOURCE_GROUP_ADMIN | RESOURCE_GROUP_USER | RESUME
+    | RETURNED_SQLSTATE | RETURNS | REUSE | ROLE | ROLE_ADMIN | ROLLBACK | ROLLUP | ROTATE | ROW | ROWS
+    | ROW_FORMAT | RTREE | S3 | SAVEPOINT | SCHEDULE | SCHEMA_NAME | SECURITY | SECONDARY_ENGINE_ATTRIBUTE | SERIAL | SERVER
+    | SESSION | SESSION_VARIABLES_ADMIN | SET_USER_ID | SHARE | SHARED | SHOW_ROUTINE | SIGNED | SIMPLE | SLAVE
+    | SLOW | SNAPSHOT | SOCKET | SOME | SONAME | SOUNDS | SOURCE
+    | SQL_AFTER_GTIDS | SQL_AFTER_MTS_GAPS | SQL_BEFORE_GTIDS
+    | SQL_BUFFER_RESULT | SQL_CACHE | SQL_NO_CACHE | SQL_THREAD
+    | STACKED | START | STARTS | STATS_AUTO_RECALC | STATS_PERSISTENT
+    | STATS_SAMPLE_PAGES | STATUS | STD | STDDEV | STDDEV_POP | STDDEV_SAMP | STOP | STORAGE | STRING
+    | SUBCLASS_ORIGIN | SUBJECT | SUBPARTITION | SUBPARTITIONS | SUM | SUSPEND | SWAPS
+    | SWITCHES | SYSTEM_VARIABLES_ADMIN | TABLE_NAME | TABLESPACE | TABLE_ENCRYPTION_ADMIN | TABLE_TYPE
+    | TEMPORARY | TEMPTABLE | THAN | TRADITIONAL
+    | TRANSACTION | TRANSACTIONAL | TRIGGERS | TRUNCATE | UNBOUNDED | UNDEFINED | UNDOFILE
+    | UNDO_BUFFER_SIZE | UNINSTALL | UNKNOWN | UNTIL | UPGRADE | USA | USER | USE_FRM | USER_RESOURCES
+    | VALIDATION | VALUE | VAR_POP | VAR_SAMP | VARIABLES | VARIANCE | VERSION_TOKEN_ADMIN | VIEW | VIRTUAL
+    | WAIT | WARNINGS | WITHOUT | WORK | WRAPPER | X509 | XA | XA_RECOVER_ADMIN | XML
+    ;
+
+functionNameBase
+    : ABS | ACOS | ADDDATE | ADDTIME | AES_DECRYPT | AES_ENCRYPT
+    | AREA | ASBINARY | ASIN | ASTEXT | ASWKB | ASWKT
+    | ASYMMETRIC_DECRYPT | ASYMMETRIC_DERIVE
+    | ASYMMETRIC_ENCRYPT | ASYMMETRIC_SIGN | ASYMMETRIC_VERIFY
+    | ATAN | ATAN2 | BENCHMARK | BIN | BIT_COUNT | BIT_LENGTH
+    | BUFFER | CEIL | CEILING | CENTROID | CHARACTER_LENGTH
+    | CHARSET | CHAR_LENGTH | COERCIBILITY | COLLATION
+    | COMPRESS | CONCAT | CONCAT_WS | CONNECTION_ID | CONV
+    | CONVERT_TZ | COS | COT | COUNT | CRC32
+    | CREATE_ASYMMETRIC_PRIV_KEY | CREATE_ASYMMETRIC_PUB_KEY
+    | CREATE_DH_PARAMETERS | CREATE_DIGEST | CROSSES | CUME_DIST | DATABASE | DATE
+    | DATEDIFF | DATE_FORMAT | DAY | DAYNAME | DAYOFMONTH
+    | DAYOFWEEK | DAYOFYEAR | DECODE | DEGREES | DENSE_RANK | DES_DECRYPT
+    | DES_ENCRYPT | DIMENSION | DISJOINT | ELT | ENCODE
+    | ENCRYPT | ENDPOINT | ENVELOPE | EQUALS | EXP | EXPORT_SET
+    | EXTERIORRING | EXTRACTVALUE | FIELD | FIND_IN_SET | FIRST_VALUE | FLOOR
+    | FORMAT | FOUND_ROWS | FROM_BASE64 | FROM_DAYS
+    | FROM_UNIXTIME | GEOMCOLLFROMTEXT | GEOMCOLLFROMWKB
+    | GEOMETRYCOLLECTION | GEOMETRYCOLLECTIONFROMTEXT
+    | GEOMETRYCOLLECTIONFROMWKB | GEOMETRYFROMTEXT
+    | GEOMETRYFROMWKB | GEOMETRYN | GEOMETRYTYPE | GEOMFROMTEXT
+    | GEOMFROMWKB | GET_FORMAT | GET_LOCK | GLENGTH | GREATEST
+    | GTID_SUBSET | GTID_SUBTRACT | HEX | HOUR | IFNULL
+    | INET6_ATON | INET6_NTOA | INET_ATON | INET_NTOA | INSTR
+    | INTERIORRINGN | INTERSECTS | INVISIBLE
+    | ISCLOSED | ISEMPTY | ISNULL
+    | ISSIMPLE | IS_FREE_LOCK | IS_IPV4 | IS_IPV4_COMPAT
+    | IS_IPV4_MAPPED | IS_IPV6 | IS_USED_LOCK | LAG | LAST_INSERT_ID | LAST_VALUE
+    | LCASE | LEAD | LEAST | LEFT | LENGTH | LINEFROMTEXT | LINEFROMWKB
+    | LINESTRING | LINESTRINGFROMTEXT | LINESTRINGFROMWKB | LN
+    | LOAD_FILE | LOCATE | LOG | LOG10 | LOG2 | LOWER | LPAD
+    | LTRIM | MAKEDATE | MAKETIME | MAKE_SET | MASTER_POS_WAIT
+    | MBRCONTAINS | MBRDISJOINT | MBREQUAL | MBRINTERSECTS
+    | MBROVERLAPS | MBRTOUCHES | MBRWITHIN | MD5 | MICROSECOND
+    | MINUTE | MLINEFROMTEXT | MLINEFROMWKB | MOD| MONTH | MONTHNAME
+    | MPOINTFROMTEXT | MPOINTFROMWKB | MPOLYFROMTEXT
+    | MPOLYFROMWKB | MULTILINESTRING | MULTILINESTRINGFROMTEXT
+    | MULTILINESTRINGFROMWKB | MULTIPOINT | MULTIPOINTFROMTEXT
+    | MULTIPOINTFROMWKB | MULTIPOLYGON | MULTIPOLYGONFROMTEXT
+    | MULTIPOLYGONFROMWKB | NAME_CONST | NTH_VALUE | NTILE | NULLIF | NUMGEOMETRIES
+    | NUMINTERIORRINGS | NUMPOINTS | OCT | OCTET_LENGTH | ORD
+    | OVERLAPS | PERCENT_RANK | PERIOD_ADD | PERIOD_DIFF | PI | POINT
+    | POINTFROMTEXT | POINTFROMWKB | POINTN | POLYFROMTEXT
+    | POLYFROMWKB | POLYGON | POLYGONFROMTEXT | POLYGONFROMWKB
+    | POSITION | POW | POWER | QUARTER | QUOTE | RADIANS | RAND | RANK
+    | RANDOM_BYTES | RELEASE_LOCK | REVERSE | RIGHT | ROUND
+    | ROW_COUNT | ROW_NUMBER | RPAD | RTRIM | SCHEMA | SECOND | SEC_TO_TIME
+    | SESSION_USER | SESSION_VARIABLES_ADMIN
+    | SHA | SHA1 | SHA2 | SIGN | SIN | SLEEP
+    | SOUNDEX | SQL_THREAD_WAIT_AFTER_GTIDS | SQRT | SRID
+    | STARTPOINT | STRCMP | STR_TO_DATE | ST_AREA | ST_ASBINARY
+    | ST_ASTEXT | ST_ASWKB | ST_ASWKT | ST_BUFFER | ST_CENTROID
+    | ST_CONTAINS | ST_CROSSES | ST_DIFFERENCE | ST_DIMENSION
+    | ST_DISJOINT | ST_DISTANCE | ST_ENDPOINT | ST_ENVELOPE
+    | ST_EQUALS | ST_EXTERIORRING | ST_GEOMCOLLFROMTEXT
+    | ST_GEOMCOLLFROMTXT | ST_GEOMCOLLFROMWKB
+    | ST_GEOMETRYCOLLECTIONFROMTEXT
+    | ST_GEOMETRYCOLLECTIONFROMWKB | ST_GEOMETRYFROMTEXT
+    | ST_GEOMETRYFROMWKB | ST_GEOMETRYN | ST_GEOMETRYTYPE
+    | ST_GEOMFROMTEXT | ST_GEOMFROMWKB | ST_INTERIORRINGN
+    | ST_INTERSECTION | ST_INTERSECTS | ST_ISCLOSED | ST_ISEMPTY
+    | ST_ISSIMPLE | ST_LINEFROMTEXT | ST_LINEFROMWKB
+    | ST_LINESTRINGFROMTEXT | ST_LINESTRINGFROMWKB
+    | ST_NUMGEOMETRIES | ST_NUMINTERIORRING
+    | ST_NUMINTERIORRINGS | ST_NUMPOINTS | ST_OVERLAPS
+    | ST_POINTFROMTEXT | ST_POINTFROMWKB | ST_POINTN
+    | ST_POLYFROMTEXT | ST_POLYFROMWKB | ST_POLYGONFROMTEXT
+    | ST_POLYGONFROMWKB | ST_SRID | ST_STARTPOINT
+    | ST_SYMDIFFERENCE | ST_TOUCHES | ST_UNION | ST_WITHIN
+    | ST_X | ST_Y | SUBDATE | SUBSTRING_INDEX | SUBTIME
+    | SYSTEM_USER | TAN | TIME | TIMEDIFF | TIMESTAMP
+    | TIMESTAMPADD | TIMESTAMPDIFF | TIME_FORMAT | TIME_TO_SEC
+    | TOUCHES | TO_BASE64 | TO_DAYS | TO_SECONDS | UCASE
+    | UNCOMPRESS | UNCOMPRESSED_LENGTH | UNHEX | UNIX_TIMESTAMP
+    | UPDATEXML | UPPER | UUID | UUID_SHORT
+    | VALIDATE_PASSWORD_STRENGTH | VERSION | VISIBLE
+    | WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS | WEEK | WEEKDAY
+    | WEEKOFYEAR | WEIGHT_STRING | WITHIN | YEAR | YEARWEEK
+    | Y_FUNCTION | X_FUNCTION
+    | JSON_ARRAY | JSON_OBJECT | JSON_QUOTE | JSON_CONTAINS | JSON_CONTAINS_PATH
+    | JSON_EXTRACT | JSON_KEYS | JSON_OVERLAPS | JSON_SEARCH | JSON_VALUE
+    | JSON_ARRAY_APPEND | JSON_ARRAY_INSERT | JSON_INSERT | JSON_MERGE
+    | JSON_MERGE_PATCH | JSON_MERGE_PRESERVE | JSON_REMOVE | JSON_REPLACE
+    | JSON_SET | JSON_UNQUOTE | JSON_DEPTH | JSON_LENGTH | JSON_TYPE
+    | JSON_VALID | JSON_TABLE | JSON_SCHEMA_VALID | JSON_SCHEMA_VALIDATION_REPORT
+    | JSON_PRETTY | JSON_STORAGE_FREE | JSON_STORAGE_SIZE | JSON_ARRAYAGG
+    | JSON_OBJECTAGG
+    ;

--- a/src/main/java/io/dbsink/connector/sink/applier/ApplierWorker.java
+++ b/src/main/java/io/dbsink/connector/sink/applier/ApplierWorker.java
@@ -76,7 +76,7 @@ public class ApplierWorker extends WorkerThread implements LifeCycle {
         while (context.isRunning()) {
             ApplierEvent applierEvent = applierEvents.take();
             Long sequenceNumber = applierEvent.getSequenceNumber();
-            if (applierEvent.hasDataChangeEvent()) {
+            if (applierEvent.getEvents().size() > 0) {
                 tableApplier.apply(applierEvent.getEvents());
             }
             Long minSequenceNumber = dispatcher.updateSequenceNoAndGet(sequenceNumber);

--- a/src/main/java/io/dbsink/connector/sink/applier/ParallelTxApplier.java
+++ b/src/main/java/io/dbsink/connector/sink/applier/ParallelTxApplier.java
@@ -36,9 +36,6 @@ public class ParallelTxApplier implements Applier<Collection<ChangeEvent>> {
 
     private final ParallelDispatcher dispatcher;
 
-    private final ConnectorContext connectorContext;
-    private final ErrorHandler errorHandler;
-
     private final Map<String, Transaction> transactionMap = new LinkedHashMap<>();
 
     private long lastCommitted;
@@ -49,18 +46,14 @@ public class ParallelTxApplier implements Applier<Collection<ChangeEvent>> {
 
     private WriteSet writeSet = new WriteSet();
 
-    private ConnectorConfig config;
 
     public ParallelTxApplier(
         ConnectorContext connectorContext,
         ErrorHandler errorHandler,
         ConnectorConfig config
     ) {
-        this.connectorContext = connectorContext;
-        this.errorHandler = errorHandler;
         this.lastCommitted = 0L;
         this.sequenceNumber = 1L;
-        this.config = config;
         this.queue = new ArrayBlockingQueue<>(config.getTransactionBufferSize());
         this.dispatcher = new ParallelDispatcher(queue, connectorContext, errorHandler, config);
     }
@@ -102,6 +95,7 @@ public class ParallelTxApplier implements Applier<Collection<ChangeEvent>> {
             }
         } catch (InterruptedException e) {
             LOGGER.warn("InterruptedException");
+            Thread.interrupted();
             throw new ApplierException("failed to apply", e);
         }
     }

--- a/src/main/java/io/dbsink/connector/sink/ddl/CaseChangingCharStream.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/CaseChangingCharStream.java
@@ -1,0 +1,74 @@
+package io.dbsink.connector.sink.ddl;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.misc.Interval;
+
+public class CaseChangingCharStream implements CharStream{
+
+    final CharStream stream;
+    final boolean upper;
+
+    /**
+     * Constructs a new CaseChangingCharStream wrapping the given {@link CharStream} forcing
+     * all characters to upper case or lower case.
+     *
+     * @param stream The stream to wrap.
+     * @param upper  If true force each symbol to upper case, otherwise force to lower.
+     */
+    public CaseChangingCharStream(CharStream stream, boolean upper) {
+        this.stream = stream;
+        this.upper = upper;
+    }
+
+    @Override
+    public String getText(Interval interval) {
+        return stream.getText(interval);
+    }
+
+    @Override
+    public void consume() {
+        stream.consume();
+    }
+
+    @Override
+    public int LA(int i) {
+        int c = stream.LA(i);
+        if (c <= 0) {
+            return c;
+        }
+        if (upper) {
+            return Character.toUpperCase(c);
+        }
+        return Character.toLowerCase(c);
+    }
+
+    @Override
+    public int mark() {
+        return stream.mark();
+    }
+
+    @Override
+    public void release(int marker) {
+        stream.release(marker);
+    }
+
+    @Override
+    public int index() {
+        return stream.index();
+    }
+
+    @Override
+    public void seek(int index) {
+        stream.seek(index);
+    }
+
+    @Override
+    public int size() {
+        return stream.size();
+    }
+
+    @Override
+    public String getSourceName() {
+        return stream.getSourceName();
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/ParserContext.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/ParserContext.java
@@ -1,0 +1,21 @@
+package io.dbsink.connector.sink.ddl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Parser Context, used by {@link io.dbsink.connector.sink.ddl.listener.MySqlToPGParserListener}
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class ParserContext {
+    private final Map<String, Object> map = new HashMap<>();
+    public <T> T get(String value) {
+        return (T) map.get(value);
+    }
+
+    public void put(String key, Object value) {
+        map.put(key, value);
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/CommonSQLConverter.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/CommonSQLConverter.java
@@ -1,0 +1,15 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+/**
+ * Base class of  each SQL converter
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public abstract class CommonSQLConverter implements SQLConverter {
+    protected final ConversionConfiguration configuration;
+
+    public CommonSQLConverter(ConversionConfiguration configuration) {
+        this.configuration = configuration;
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionConfiguration.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionConfiguration.java
@@ -1,0 +1,28 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import io.dbsink.connector.sink.naming.ColumnNamingStrategy;
+import io.dbsink.connector.sink.naming.TableNamingStrategy;
+
+/**
+ * Conversion configuration used by sql converter
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class ConversionConfiguration {
+    private ColumnNamingStrategy columnNamingStrategy;
+    private TableNamingStrategy tableNamingStrategy;
+
+    public ConversionConfiguration(TableNamingStrategy tableNamingStrategy, ColumnNamingStrategy columnNamingStrategy) {
+        this.tableNamingStrategy = tableNamingStrategy;
+        this.columnNamingStrategy = columnNamingStrategy;
+    }
+
+    public ColumnNamingStrategy getColumnNamingStrategy() {
+        return columnNamingStrategy;
+    }
+
+    public TableNamingStrategy getTableNamingStrategy() {
+        return tableNamingStrategy;
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionMessage.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionMessage.java
@@ -1,0 +1,84 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * DDL conversion message
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class ConversionMessage {
+    private final List<String> warnings;
+    private final List<String> infos;
+
+    public ConversionMessage() {
+        this.warnings = new ArrayList<>();
+        this.infos = new ArrayList<>();
+    }
+
+    /**
+     * Get conversion info messages
+     *
+     * @return conversion info messages
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public List<String> getInfoMessages() {
+        return Collections.unmodifiableList(infos);
+    }
+
+    /**
+     * Get warning info messages
+     *
+     * @return conversion warning messages
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public List<String> getWarningMessages() {
+        return Collections.unmodifiableList(warnings);
+    }
+
+
+    /**
+     * Put a message with the specified level
+     *
+     * @param  message conversion message
+     * @param  level   message level
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public void report(String message, Level level) {
+        switch (level) {
+            case INFO: {
+                infos.add(message);
+            }
+            break;
+            case WARNING: {
+                warnings.add(message);
+            }
+            break;
+            default:
+                throw new IllegalArgumentException("message level is not valid");
+        }
+    }
+
+    /**
+     * Message level
+     *
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public enum Level {
+        /**
+         * Info level
+         */
+        INFO,
+        /**
+         * Warning level
+         */
+        WARNING
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionResult.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionResult.java
@@ -1,0 +1,132 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * DDL Conversion Result
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class ConversionResult {
+    private final ConversionStatus status;
+    private final List<String> warnings;
+    private final List<String> infos;
+    private final String error;
+    private final List<String> statements;
+
+    public ConversionResult(
+        List<String> statements,
+        ConversionStatus status,
+        List<String> infos,
+        List<String> warnings,
+        String error
+    ) {
+        this.statements = statements;
+        this.status = status;
+        this.infos = infos;
+        this.warnings = warnings;
+        this.error = error;
+    }
+
+    /**
+     * Get the converted SQL statements.
+     * Remember one statement from the source database may be converted into
+     * multiple statements in the target database, it's a one-to-many relationship.
+     *
+     * @return sql statements
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public List<String> getStatements() {
+        return Collections.unmodifiableList(statements);
+    }
+
+    /**
+     * Get conversion status
+     *
+     * @return conversion status {@link ConversionStatus}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public ConversionStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Get conversion warning messages
+     *
+     * @return conversion warning messages
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public List<String> getWarnings() {
+        return Collections.unmodifiableList(warnings);
+    }
+
+
+    /**
+     * Get conversion info messages
+     *
+     * @return conversion info messages
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public List<String> getInfos() {
+        return Collections.unmodifiableList(infos);
+    }
+
+    /**
+     * Get conversion error messages
+     *
+     * @return conversion error messages
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public String getErrors() {
+        return error;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private ConversionStatus status;
+        private List<String> warnings;
+        private List<String> infos;
+        private String error;
+        private List<String> statements;
+
+        public Builder status(ConversionStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder warnings(List<String> warnings) {
+            this.warnings = warnings;
+            return this;
+        }
+
+        public Builder infos(List<String> infos) {
+            this.infos = infos;
+            return this;
+        }
+
+        public Builder error(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public Builder statements(List<String> statements) {
+            this.statements = statements;
+            return this;
+        }
+
+        public ConversionResult build() {
+            return new ConversionResult(statements, status, infos, warnings, error);
+        }
+    }
+
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionStatus.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/ConversionStatus.java
@@ -1,0 +1,18 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+/**
+ * DDL Conversion Status
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public enum ConversionStatus {
+    /**
+     * Succeeded to convert sql statement from source database to target database
+     */
+    SUCCEEDED,
+    /**
+     * Failed to convert sql statement from source database to target database
+     */
+    FAILED
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/MySqlToPGConverter.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/MySqlToPGConverter.java
@@ -1,0 +1,77 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import io.dbsink.connector.sink.ddl.CaseChangingCharStream;
+import io.dbsink.connector.sink.ddl.listener.MySqlToPGParserListener;
+import io.dbsink.connector.sink.ddl.listener.ParserErrorListener;
+import io.dbsink.connector.sink.ddl.parser.mysql.MySqlLexer;
+import io.dbsink.connector.sink.ddl.parser.mysql.MySqlParser;
+import io.dbsink.connector.sink.dialect.DatabaseType;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import java.util.concurrent.CancellationException;
+
+/**
+ * MySql to PostgreSQL DDL SQL converter
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class MySqlToPGConverter extends CommonSQLConverter {
+
+    public MySqlToPGConverter(ConversionConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public ConversionResult convert(String statement) {
+        CodePointCharStream ddlContentCharStream = CharStreams.fromString(statement);
+        Lexer lexer = new MySqlLexer(new CaseChangingCharStream(ddlContentCharStream, true));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        MySqlParser parser = new MySqlParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(new ParserErrorListener());
+        ParseTree parseTree = parser.root();
+        ParseTreeWalker parseTreeWalker = new ParseTreeWalker();
+        MySqlToPGParserListener parserListener = new MySqlToPGParserListener(tokens, configuration);
+        ConversionStatus status = ConversionStatus.SUCCEEDED;
+        String error = "";
+        try {
+            parseTreeWalker.walk(parserListener, parseTree);
+        } catch (CancellationException e) {
+            status = ConversionStatus.FAILED;
+            error = e.getMessage();
+        }
+        ConversionMessage message = parserListener.getMessage();
+        return ConversionResult.builder()
+            .statements(parserListener.getStatements())
+            .status(status)
+            .infos(message.getInfoMessages())
+            .warnings(message.getWarningMessages())
+            .error(error)
+            .build();
+    }
+
+    public static class MySqlToPGConverterProvider implements SQLConverterProvider {
+
+        @Override
+        public DatabaseType sourceDatabase() {
+            return DatabaseType.MYSQL;
+        }
+
+        @Override
+        public DatabaseType targetDatabase() {
+            return DatabaseType.POSTGRES;
+        }
+
+        @Override
+        public SQLConverter create(ConversionConfiguration configuration) {
+            return new MySqlToPGConverter(configuration);
+        }
+    }
+
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverter.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverter.java
@@ -1,0 +1,20 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+/**
+ * SQL converter
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public interface SQLConverter {
+
+    /**
+     * Convert sql statement from source database to target database
+     *
+     * @param statement sql statement
+     * @return SQL conversion result {@link ConversionResult}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    ConversionResult convert(String statement);
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverterProvider.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverterProvider.java
@@ -1,0 +1,39 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import io.dbsink.connector.sink.dialect.DatabaseType;
+
+/**
+ * SQL converter provider
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public interface SQLConverterProvider {
+    /**
+     * Source database of the SQL converter
+     *
+     * @return database type {@link DatabaseType}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    DatabaseType sourceDatabase();
+
+    /**
+     * Target database of the SQL converter
+     *
+     * @return database type {@link DatabaseType}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    DatabaseType targetDatabase();
+
+    /**
+     * Create SQL converter
+     *
+     * @param configuration {@link ConversionConfiguration}
+     * @return SQL converter {@link SQLConverter}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    SQLConverter create(ConversionConfiguration configuration);
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverters.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/converters/SQLConverters.java
@@ -1,0 +1,56 @@
+package io.dbsink.connector.sink.ddl.converters;
+
+import io.dbsink.connector.sink.dialect.DatabaseType;
+import io.dbsink.connector.sink.util.Pair;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * SQL converters, loads all SQL converter {@link SQLConverter} and
+ * provides an interface to create a converter
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class SQLConverters {
+
+    private static Map<Pair<DatabaseType, DatabaseType>, SQLConverterProvider> SQL_CONVERTER_REGISTRY = new HashMap<>();
+
+    static {
+        loadSQLConverters();
+    }
+
+    private static void loadSQLConverters() {
+        for (SQLConverterProvider converterProvider : ServiceLoader.load(SQLConverterProvider.class)) {
+            DatabaseType sourceDatabase = converterProvider.sourceDatabase();
+            DatabaseType targetDatabase = converterProvider.targetDatabase();
+            SQL_CONVERTER_REGISTRY.put(Pair.of(sourceDatabase, targetDatabase), converterProvider);
+        }
+    }
+
+    /**
+     * Create SQL converter
+     *
+     * @param sourceDatabase source database {@link DatabaseType}
+     * @param targetDatabase target database {@link DatabaseType}
+     * @param configuration  conversion configuration {@link ConversionConfiguration}
+     * @return SQL converter {@link SQLConverter}
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static SQLConverter create(
+        DatabaseType sourceDatabase,
+        DatabaseType targetDatabase,
+        ConversionConfiguration configuration
+    ) {
+        SQLConverterProvider converterProvider = SQL_CONVERTER_REGISTRY.get(Pair.of(sourceDatabase, targetDatabase));
+        if (converterProvider == null) {
+            throw new ConnectException("sql conversion from \"" + sourceDatabase + "\" to \""
+                + targetDatabase + "\" is not supported!");
+        }
+        return converterProvider.create(configuration);
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/listener/MySqlDataTypeToPGMap.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/listener/MySqlDataTypeToPGMap.java
@@ -1,0 +1,42 @@
+package io.dbsink.connector.sink.ddl.listener;
+
+import io.dbsink.connector.sink.ddl.parser.mysql.MySqlParser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mapping of data types between MySQL and PostgreSQL, used by {@link MySqlToPGParserListener}
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class MySqlDataTypeToPGMap {
+    private static Map<Integer, String> map = new HashMap<>();
+    static {
+        map.put(MySqlParser.SMALLINT, "SMALLINT");
+        map.put(MySqlParser.YEAR, "SMALLINT");
+        map.put(MySqlParser.MEDIUMBLOB, "BYTEA");
+        map.put(MySqlParser.BIGINT, "BIGINT");
+        map.put(MySqlParser.INTEGER, "INTEGER");
+        map.put(MySqlParser.LONGBLOB, "BYTEA");
+        map.put(MySqlParser.MEDIUMBLOB, "BYTEA");
+        map.put(MySqlParser.DATE, "DATE");
+        map.put(MySqlParser.BLOB, "BYTEA");
+        map.put(MySqlParser.TINYBLOB, "BYTEA");
+        map.put(MySqlParser.VARBINARY, "BYTEA");
+        map.put(MySqlParser.BINARY, "BYTEA");
+        map.put(MySqlParser.TEXT, "TEXT");
+        map.put(MySqlParser.MEDIUMTEXT, "TEXT");
+        map.put(MySqlParser.LONGTEXT, "TEXT");
+        map.put(MySqlParser.BOOLEAN, "BOOLEAN");
+        map.put(MySqlParser.INT, "int");
+    }
+    public static String get(Integer dataType) {
+        return map.get(dataType);
+    }
+
+    public static boolean contains(Integer dataType) {
+        return map.containsKey(dataType);
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/listener/MySqlToPGParserListener.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/listener/MySqlToPGParserListener.java
@@ -1,0 +1,643 @@
+package io.dbsink.connector.sink.ddl.listener;
+
+import io.dbsink.connector.sink.ddl.converters.ConversionMessage;
+import io.dbsink.connector.sink.ddl.converters.ConversionMessage.Level;
+import io.dbsink.connector.sink.ddl.ParserContext;
+import io.dbsink.connector.sink.ddl.converters.ConversionConfiguration;
+import io.dbsink.connector.sink.ddl.parser.mysql.MySqlParser;
+import io.dbsink.connector.sink.ddl.parser.mysql.MySqlParserBaseListener;
+import io.dbsink.connector.sink.naming.ColumnNamingStrategy;
+import io.dbsink.connector.sink.naming.TableNamingStrategy;
+import io.dbsink.connector.sink.relation.TableId;
+import io.dbsink.connector.sink.util.StringUtil;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * MySQL to PostgreSQL parser listener, used to rewrite sql in MySQL into PostgreSQL
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class MySqlToPGParserListener extends MySqlParserBaseListener {
+
+    private final static String TABLE_ID = "TABLE_ID";
+
+    private final static String COLUMN_CREAT_TABLE_CONTEXT = "COLUMN_CREAT_TABLE_CONTEXT";
+
+    private final static String COLUMN_INDEX = "COLUMN_INDEX";
+
+    private final static String PARSE_RULE_CONTEXT = "PARSE_RULE_CONTEXT";
+
+    private final static String COLUMN_DECLARATION_CONTEXT = "COLUMN_DECLARATION_CONTEXT";
+
+    private final static String TABLE_OPTION_AUTOINCREMENT_CONTEXT = "TABLE_OPTION_AUTOINCREMENT_CONTEXT";
+
+    private final static String CREATE_INDEX_TEMPLATE = "CREATE INDEX %s ON %s(%s)";
+
+    private final static String CREATE_ENUM_TEMPLATE = "CREATE TYPE %s AS ENUM(%s)";
+
+    private final static String CREATE_COMMENT_ON_COLUMN_TEMPLATE = "COMMENT ON COLUMN %s.%s is %s";
+
+    private final static String CREATE_COMMENT_ON_TABLE_TEMPLATE = "COMMENT ON TABLE %s is %s";
+
+    private final static String ALTER_TABLE_COLUMN_NAME = "ALTER TABLE %s RENAME %s TO %s";
+
+    private final static String ALTER_TABLE_FOREIGN_KEY = "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY(%s) REFERENCES %s(%s)";
+
+    private final static String CREATE_SEQUENCE_TEMPLATE = "CREATE SEQUENCE %s increment by 1 minvalue %d no maxvalue start with %d";
+
+    private final static String CREATE_PRIMARY_KEY_TEMPLATE = "ALTER TABLE %s ADD CONSTRAINT %s PRIMARY KEY (%s)";
+
+    private final static String CREATE_UNIQUE_KEY_TEMPLATE = "ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)";
+
+    private final static String ALTER_SEQUENCE_OWNER_TEMPLATE = "ALTER SEQUENCE %s OWNED BY %s.%s";
+
+    private final TokenStreamRewriter rewriter;
+
+    private final ParserContext context = new ParserContext();
+
+    private final List<String> beforeStatements = new ArrayList<>();
+
+    private final List<String> afterStatements = new ArrayList<>();
+
+    private final ConversionMessage message;
+
+    private final ColumnNamingStrategy columnNamingStrategy;
+
+    private final TableNamingStrategy tableNamingStrategy;
+
+    public MySqlToPGParserListener(TokenStream tokenStream, ConversionConfiguration configuration) {
+        this.rewriter = new TokenStreamRewriter(tokenStream);
+        this.message = new ConversionMessage();
+        this.columnNamingStrategy = configuration.getColumnNamingStrategy();
+        this.tableNamingStrategy = configuration.getTableNamingStrategy();
+    }
+
+    public List<String> getStatements() {
+        List<String> statements = new ArrayList<>(beforeStatements.size() + afterStatements.size() + 1 );
+        statements.addAll(beforeStatements);
+        statements.add(rewriter.getText());
+        statements.addAll(afterStatements);
+        return Collections.unmodifiableList(statements);
+    }
+
+    public ConversionMessage getMessage() {
+        return message;
+    }
+
+    @Override
+    public void exitCreateDatabase(MySqlParser.CreateDatabaseContext ctx) {
+        for (MySqlParser.CreateDatabaseOptionContext createDatabaseOptionContext : ctx.createDatabaseOption()) {
+            comment(createDatabaseOptionContext.getStart(), createDatabaseOptionContext.getStop());
+        }
+        rewriter.replace(ctx.DATABASE().getSymbol(), "SCHEMA");
+    }
+
+    @Override
+    public void enterColumnDeclaration(MySqlParser.ColumnDeclarationContext ctx) {
+        context.put(COLUMN_DECLARATION_CONTEXT, ctx);
+    }
+
+    private void rewriteCollectionDataType(String columnName, MySqlParser.CollectionDataTypeContext ctx) {
+        TableId tableId = context.get(TABLE_ID);
+        if (MySqlDataTypeToPGMap.contains(ctx.typeName.getType())) {
+            rewriter.replace(ctx.getStart(), ctx.getStop(), MySqlDataTypeToPGMap.get(ctx.typeName.getType()));
+            return;
+        }
+        if (ctx.typeName.getType() == MySqlParser.ENUM) {
+            String enumValues = ctx.collectionOptions()
+                    .STRING_LITERAL()
+                    .stream()
+                    .map(collectionOptionContext -> StringUtil.quote(collectionOptionContext.getText(), '\''))
+                    .collect(Collectors.joining(","));
+            String enumName = StringUtil.unquote(tableId.getTable()) + "_" + StringUtil.unquote(columnName);
+            String sql = String.format(CREATE_ENUM_TEMPLATE, StringUtil.quote(enumName, '"'),  enumValues);
+            beforeStatements.add(sql);
+            rewriter.replace(ctx.getStart(), ctx.getStop(), StringUtil.quote(enumName, '"'));
+        }
+    }
+
+
+    @Override
+    public void exitSimpleDataType(MySqlParser.SimpleDataTypeContext ctx) {
+
+    }
+
+    private void rewriteStringDataTypeContext(MySqlParser.StringDataTypeContext ctx) {
+        if (ctx.charSet() != null) {
+            comment(ctx.charSet().getStart(), ctx.charsetName().getStop());
+        }
+
+        if (ctx.COLLATE() != null) {
+            comment(ctx.COLLATE().getSymbol(), ctx.collationName().getStop());
+        }
+
+        if (MySqlDataTypeToPGMap.contains(ctx.typeName.getType())) {
+            rewriter.replace(ctx.typeName, MySqlDataTypeToPGMap.get(ctx.typeName.getType()));
+        }
+    }
+
+    private void rewriteDimensionDataType(MySqlParser.DimensionDataTypeContext ctx) {
+        int type = ctx.typeName.getType();
+        if ((ctx.lengthOneDimension() != null) && (type == MySqlParser.TINYINT
+                || type == MySqlParser.INT || type == MySqlParser.BIGINT
+                || type == MySqlParser.SMALLINT || type == MySqlParser.MEDIUMINT)) {
+            comment(ctx.lengthOneDimension().getStart(), ctx.lengthOneDimension().getStop());
+            message.report("NOT SUPPORT SPECIFY DISPLAY WIDTH", Level.INFO);
+        }
+        for (TerminalNode unsigned :  ctx.UNSIGNED()) {
+            comment(unsigned.getSymbol());
+        }
+        if (MySqlDataTypeToPGMap.contains(ctx.typeName.getType())) {
+            rewriter.replace(ctx.typeName, MySqlDataTypeToPGMap.get(ctx.typeName.getType()));
+            return;
+        }
+        if (ctx.typeName.getType() == MySqlParser.TINYINT) {
+            if (ctx.lengthOneDimension() != null && "1".equals(ctx.lengthOneDimension().decimalLiteral().getText())) {
+                rewriter.replace(ctx.TINYINT().getSymbol(), "BOOLEAN");
+            } else {
+                rewriter.replace(ctx.TINYINT().getSymbol(), "SMALLINT");
+            }
+        }
+        if (ctx.typeName.getType() == MySqlParser.FLOAT) {
+            if (ctx.lengthOneDimension() == null && ctx.lengthTwoOptionalDimension() == null) {
+                rewriter.replace(ctx.FLOAT().getSymbol(), "REAL");
+            }
+            if (ctx.lengthTwoOptionalDimension() != null) {
+                rewriter.replace(ctx.FLOAT().getSymbol(), "NUMERIC");
+            }
+        }
+        if (ctx.typeName.getType() == MySqlParser.DOUBLE) {
+            if (ctx.lengthOneDimension() == null && ctx.lengthTwoDimension() == null) {
+                rewriter.replace(ctx.DOUBLE().getSymbol(), "DOUBLE PRECISION");
+            }
+            if (ctx.lengthTwoDimension() != null) {
+                rewriter.replace(ctx.DOUBLE().getSymbol(), "NUMERIC");
+            }
+        }
+        if (ctx.typeName.getType() == MySqlParser.TIMESTAMP) {
+            String precision = null;
+            if (ctx.lengthOneDimension() != null) {
+                precision = ctx.lengthOneDimension().getText();
+                rewriter.delete(ctx.lengthOneDimension().getStart(), ctx.lengthOneDimension().getStop());
+            }
+            if  (precision == null) {
+                rewriter.replace(ctx.TIMESTAMP().getSymbol(), "TIMESTAMP WITH TIME ZONE");
+            } else {
+                rewriter.replace(ctx.TIMESTAMP().getSymbol(), "TIMESTAMP" + precision + " WITH TIME ZONE");
+            }
+        }
+        if (ctx.typeName.getType() == MySqlParser.DATETIME) {
+            String precision = null;
+            if (ctx.lengthOneDimension() != null) {
+                precision = ctx.lengthOneDimension().getText();
+                rewriter.delete(ctx.lengthOneDimension().getStart(), ctx.lengthOneDimension().getStop());
+            }
+            if  (precision == null) {
+                rewriter.replace(ctx.DATETIME().getSymbol(), "TIMESTAMP WITHOUT TIME ZONE");
+            } else {
+                rewriter.replace(ctx.DATETIME().getSymbol(), "TIMESTAMP" + precision + " WITHOUT TIME ZONE");
+            }
+        }
+        if (ctx.typeName.getType() == MySqlParser.DATE) {
+            rewriter.replace(ctx.DATETIME().getSymbol(), "TIMESTAMP(0) WITHOUT TIME ZONE");
+        }
+    }
+
+    private TableId parseTableId(String identifier) {
+        if (!identifier.contains(".")) {
+            return new TableId(null, null, StringUtil.unquote(identifier, '`'));
+        }
+        String[] result = new String[2];
+        String delimiter = "`";
+        Pattern pattern = Pattern.compile(delimiter + "([^" + delimiter + "]+)" + delimiter + "\\." + delimiter + "([^" + delimiter + "]+)" + delimiter);
+        Matcher matcher = pattern.matcher(identifier);
+
+        if (matcher.find()) {
+            result[0] = matcher.group(1);
+            result[1] = matcher.group(2);
+            return new TableId(result[0], null, result[1]);
+        }
+        throw new IllegalArgumentException("illegal identifier \"" + identifier + "\"");
+    }
+
+    @Override
+    public void enterColumnCreateTable(MySqlParser.ColumnCreateTableContext ctx) {
+        TableId tableId = parseTableId(ctx.tableName().fullId().getText());
+        tableId = tableNamingStrategy.resolveTableId(tableId);
+        context.put(TABLE_ID,  tableId);
+        context.put(COLUMN_CREAT_TABLE_CONTEXT, ctx);
+        for (MySqlParser.TableOptionContext tableOptionContext : ctx.tableOption()) {
+            if (tableOptionContext instanceof MySqlParser.TableOptionAutoIncrementContext) {
+                context.put(TABLE_OPTION_AUTOINCREMENT_CONTEXT, tableOptionContext);
+            }
+        }
+    }
+
+
+    @Override
+    public void exitDropTable(MySqlParser.DropTableContext ctx) {
+        for (MySqlParser.TableNameContext tableNameContext : ctx.tables().tableName()) {
+            TableId tableId = parseTableId(tableNameContext.fullId().getText());
+            rewriter.replace(tableNameContext.fullId().getStart(), tableNameContext.fullId().getStop(), tableId.toQuoted('"'));
+        }
+        rewriter.insertAfter(ctx.getStop(), " cascade");
+    }
+
+    @Override
+    public void exitColumnCreateTable(MySqlParser.ColumnCreateTableContext ctx) {
+        context.put(PARSE_RULE_CONTEXT, ctx);
+        TableId tableId = context.get(TABLE_ID);
+        tableId = tableNamingStrategy.resolveTableId(tableId);
+        rewriter.replace(ctx.tableName().getStart(), ctx.tableName().getStop(), tableId.toQuoted('"'));
+        List<MySqlParser.CreateDefinitionContext> createDefinitionContexts = ctx.createDefinitions().createDefinition();
+        for (int i = 0; i < createDefinitionContexts.size(); i++) {
+            context.put(COLUMN_INDEX, i);
+            MySqlParser.CreateDefinitionContext createDefinitionContext = createDefinitionContexts.get(i);
+            if (createDefinitionContext instanceof MySqlParser.IndexDeclarationContext) {
+                rewriteIndexDeclaration((MySqlParser.IndexDeclarationContext)createDefinitionContext);
+            }
+            if (createDefinitionContext instanceof MySqlParser.ConstraintDeclarationContext) {
+                rewriteConstraintDeclarationContext(((MySqlParser.ConstraintDeclarationContext)createDefinitionContext).tableConstraint());
+            }
+            if (createDefinitionContext instanceof MySqlParser.ColumnDeclarationContext) {
+                rewriteColumnDeclaration((MySqlParser.ColumnDeclarationContext) createDefinitionContext);
+            }
+        }
+    }
+
+    @Override
+    public void exitCreateView(MySqlParser.CreateViewContext ctx) {
+        comment(ctx.ownerStatement().getStart(), ctx.ownerStatement().getStop());
+        comment(ctx.ALGORITHM().getSymbol(), ctx.algType);
+        comment(ctx.SQL().getSymbol(), ctx.secContext);
+
+        //rewriter.delete(ctx.secContext);
+        //rewriter.delete(ctx.DEFINER());
+
+    }
+
+    private void comment(Token start, Token end) {
+        rewriter.insertBefore(start, "/* ");
+        rewriter.insertAfter(end, " */");
+    }
+    private void comment(Token start) {
+        rewriter.insertBefore(start, "/* ");
+        rewriter.insertAfter(start, " */");
+    }
+    private void rewriteColumnDeclaration(MySqlParser.ColumnDeclarationContext ctx) {
+        String columnName = StringUtil.unquote(ctx.fullColumnName().uid().getText(), '`');
+        columnName = columnNamingStrategy.resolveColumnName(columnName);
+        rewriter.replace(ctx.fullColumnName().uid().getStart(), ctx.fullColumnName().uid().getStop(),
+            StringUtil.quote(columnName, '"'));
+        rewriteColumnDefinition(ctx.fullColumnName().getText(), ctx.columnDefinition());
+    }
+
+    private void rewriteUniqueKeyTableConstraint(MySqlParser.UniqueKeyTableConstraintContext ctx) {
+        int columnIndex = context.get(COLUMN_INDEX);
+        MySqlParser.ColumnCreateTableContext columnCreateTableContext = context.get(COLUMN_CREAT_TABLE_CONTEXT);
+        List<String> columnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+        String columnParts = String.join(",", columnNames);
+        TableId tableId = context.get(TABLE_ID);
+        if (ctx.index != null) {
+            afterStatements.add(String.format(CREATE_UNIQUE_KEY_TEMPLATE, tableId.getTable(),
+                    StringUtil.quote(tableId.getTable() + "_" + StringUtil.unquote(ctx.index.getText()), '"'), columnParts));
+            rewriter.delete(ctx.getStart(), ctx.getStop());
+            if (columnIndex > 0) {
+                rewriter.delete(columnCreateTableContext.createDefinitions().COMMA(columnIndex - 1).getSymbol());
+            }
+            return;
+        }
+        rewriter.replace(ctx.UNIQUE().getSymbol(), "UNIQUE KEY");
+        for (MySqlParser.IndexOptionContext indexOptionContext : ctx.indexOption()) {
+            comment(indexOptionContext.getStart(), indexOptionContext.getStop());
+        }
+    }
+
+    private void rewriteConstraintDeclarationContext(MySqlParser.TableConstraintContext ctx) {
+        if (ctx instanceof MySqlParser.UniqueKeyTableConstraintContext) {
+            rewriteUniqueKeyTableConstraint((MySqlParser.UniqueKeyTableConstraintContext) ctx);
+        }
+        if (ctx instanceof MySqlParser.PrimaryKeyTableConstraintContext) {
+            rewritePrimaryKeyTableConstraint((MySqlParser.PrimaryKeyTableConstraintContext) ctx);
+        }
+        if (ctx instanceof MySqlParser.ForeignKeyTableConstraintContext) {
+            rewriteForeignKeyTableConstraint((MySqlParser.ForeignKeyTableConstraintContext) ctx);
+        }
+    }
+
+    void rewriteForeignKeyTableConstraint(MySqlParser.ForeignKeyTableConstraintContext ctx) {
+        final int columnIndex = context.get(COLUMN_INDEX);
+        final MySqlParser.ColumnCreateTableContext columnCreateTableContext = context.get(COLUMN_CREAT_TABLE_CONTEXT);
+        final TableId tableId = context.get(TABLE_ID);;
+        MySqlParser.ReferenceDefinitionContext referenceDefinitionContext = ctx.referenceDefinition();
+        TableId refTableId = parseTableId(referenceDefinitionContext.tableName().fullId().getText());
+        List<String> refColumnNames = getColumnNamesFromIndexColumnNameContext(referenceDefinitionContext.indexColumnNames());
+        List<String> foreignColumnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+        String tableName = tableId.toQuoted('"').toString();
+        String sql = String.format(ALTER_TABLE_FOREIGN_KEY, tableName,
+                StringUtil.quote(ctx.name.simpleId().getText(), '"'),
+                String.join(",", foreignColumnNames), refTableId.toQuoted('"'),
+                String.join(",", refColumnNames));
+        afterStatements.add(sql);
+        if (columnIndex > 0) {
+            rewriter.delete(columnCreateTableContext.createDefinitions().COMMA(columnIndex - 1).getSymbol());
+        }
+        rewriter.delete(ctx.getStart(), ctx.getStop());
+    }
+
+    void rewritePrimaryKeyTableConstraint(MySqlParser.PrimaryKeyTableConstraintContext ctx) {
+        int columnIndex = context.get(COLUMN_INDEX);
+        MySqlParser.ColumnCreateTableContext columnCreateTableContext = context.get(COLUMN_CREAT_TABLE_CONTEXT);
+        TableId tableId = context.get(TABLE_ID);
+        for (MySqlParser.IndexOptionContext indexOptionContext : ctx.indexOption()) {
+            comment(indexOptionContext.getStart(), indexOptionContext.getStop());
+        }
+        List<String> columnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+        if (ctx.index != null) {
+            String columnParts = String.join(",", columnNames);
+            afterStatements.add(String.format(CREATE_PRIMARY_KEY_TEMPLATE, tableId.getTable(),
+                    StringUtil.quote(tableId.getTable() + "_" + StringUtil.unquote(ctx.index.getText()), '"'), columnParts));
+            rewriter.delete(ctx.getStart(), ctx.getStop());
+            if (columnIndex > 0) {
+                rewriter.delete(columnCreateTableContext.createDefinitions().COMMA(columnIndex - 1).getSymbol());
+            }
+        }
+       // List<String> columnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+       // String columnParts = String.join(",", columnNames);
+       // rewriter.replace(ctx.getStart(), ctx.getStop(), "PRIMARY KEY(" + columnParts + ")");
+    }
+
+
+    private void rewriteIndexDeclaration(MySqlParser.IndexDeclarationContext ctx) {
+        MySqlParser.IndexColumnDefinitionContext indexColumnDefinitionContext = ctx.indexColumnDefinition();
+        if (indexColumnDefinitionContext instanceof MySqlParser.SimpleIndexDeclarationContext) {
+            rewriteSimpleIndexDeclaration((MySqlParser.SimpleIndexDeclarationContext) indexColumnDefinitionContext);
+        }
+        if (indexColumnDefinitionContext instanceof MySqlParser.SpecialIndexDeclarationContext) {
+            rewriteSpecialIndexDeclaration((MySqlParser.SpecialIndexDeclarationContext) indexColumnDefinitionContext);
+        }
+    }
+
+    private void rewriteSpecialIndexDeclaration(MySqlParser.SpecialIndexDeclarationContext ctx) {
+        final String tableId = context.get(TABLE_ID);
+        final MySqlParser.ColumnCreateTableContext columnCreateTableContext = context.get(COLUMN_CREAT_TABLE_CONTEXT);
+        List<String> columnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+        for (MySqlParser.IndexColumnNameContext indexColumnNameContext : ctx.indexColumnNames().indexColumnName()) {
+            String columnName = indexColumnNameContext.getText();
+            columnNames.add(StringUtil.quote(StringUtil.unquote(columnName, '`'), '"'));
+        }
+        rewriter.delete(ctx.getStart(), ctx.getStop());
+        String columnParts = String.join(",", columnNames);
+        afterStatements.add(String.format(CREATE_INDEX_TEMPLATE, tableId, columnParts));
+    }
+
+    private void rewriteSimpleIndexDeclaration(MySqlParser.SimpleIndexDeclarationContext ctx) {
+        final TableId tableId = context.get(TABLE_ID);
+        final int columnIndex = context.get(COLUMN_INDEX);
+        final MySqlParser.ColumnCreateTableContext columnCreateTableContext = context.get(COLUMN_CREAT_TABLE_CONTEXT);
+        final MySqlParser.ColumnDeclarationContext ColumnDeclarationContext = context.get(COLUMN_DECLARATION_CONTEXT);
+        final String columnName = ColumnDeclarationContext.fullColumnName().getText();
+        List<String> columnNames = getColumnNamesFromIndexColumnNameContext(ctx.indexColumnNames());
+        if (columnIndex > 0) {
+            rewriter.delete(columnCreateTableContext.createDefinitions().COMMA(columnIndex - 1).getSymbol());
+        }
+        Token token = ctx.getStop();
+        rewriter.delete(ctx.getStart(), ctx.getStop());
+        String columnParts = String.join(",", columnNames);
+        String indexName;
+        if (ctx.uid() != null) {
+            indexName = StringUtil.quote(tableId.getTable() + "_" +  StringUtil.unquote(ctx.uid().getText()), '"');
+        } else {
+            indexName = StringUtil.quote(tableId.getTable() + "_" + columnName, '"');
+        }
+        afterStatements.add(String.format(CREATE_INDEX_TEMPLATE, indexName, tableId.toQuoted('"'), columnParts));
+    }
+
+    @Override
+    public void exitTableOptionEngine(MySqlParser.TableOptionEngineContext ctx) {
+        comment(ctx.getStart(), ctx.getStop());
+    }
+
+    @Override
+    public void exitTableOptionCollate(MySqlParser.TableOptionCollateContext ctx) {
+        rewriter.delete(ctx.getStart(), ctx.getStop());
+    }
+
+
+    @Override
+    public void exitUid(MySqlParser.UidContext ctx) {
+        //rewriter.replace(ctx.getStart(), ctx.getStop(),  StringUtil.quote(ctx.getText(), '"'));
+    }
+
+    @Override
+    public void exitAlterTable(MySqlParser.AlterTableContext ctx) {
+        TableId tableId = parseTableId(ctx.tableName().fullId().getText());
+        context.put(TABLE_ID, tableId);
+        context.put(PARSE_RULE_CONTEXT, ctx);
+        rewriter.replace(ctx.tableName().getStart(), ctx.tableName().getStop(), tableId.toQuoted('"').identifier());
+        List<MySqlParser.AlterSpecificationContext> alterSpecificationContexts = ctx.alterSpecification();
+        for (MySqlParser.AlterSpecificationContext alterSpecificationContext : alterSpecificationContexts) {
+            if (alterSpecificationContext instanceof MySqlParser.AlterByModifyColumnContext) {
+                rewriteAlterByModifyColumn((MySqlParser.AlterByModifyColumnContext) alterSpecificationContext);
+            }
+            if (alterSpecificationContext instanceof MySqlParser.AlterByChangeColumnContext) {
+                rewriteAlterByChangeColumn((MySqlParser.AlterByChangeColumnContext) alterSpecificationContext);
+            }
+            if (alterSpecificationContext instanceof MySqlParser.AlterByAddColumnContext) {
+                rewriteAlterByAddColumn((MySqlParser.AlterByAddColumnContext) alterSpecificationContext);
+            }
+            if (alterSpecificationContext instanceof MySqlParser.AlterByDropColumnContext) {
+                rewriteAlterByDropColumn((MySqlParser.AlterByDropColumnContext) alterSpecificationContext);
+            }
+            if (alterSpecificationContext instanceof MySqlParser.AlterByAddColumnsContext) {
+                rewriteAlterByAddColumns((MySqlParser.AlterByAddColumnsContext) alterSpecificationContext);
+            }
+        }
+    }
+
+    private void rewriteAlterByDropColumn( MySqlParser.AlterByDropColumnContext ctx) {
+        String columnFullName = ctx.uid().getText();
+        rewriter.replace(ctx.uid().getStart(), ctx.uid().getStop(), StringUtil.quote(columnFullName, '"'));
+    }
+    private void rewriteAlterByAddColumns(MySqlParser.AlterByAddColumnsContext ctx) {
+        for (int i = 0; i < ctx.uid().size(); i++) {
+            String columnFullName = ctx.uid(i).getText();
+            rewriteColumnDefinition(columnFullName, ctx.columnDefinition(i));
+        }
+
+    }
+    private void rewriteAlterByAddColumn(MySqlParser.AlterByAddColumnContext ctx) {
+        String columnFullName = StringUtil.unquote(ctx.uid().get(0).getText(), '`');
+        columnFullName = columnNamingStrategy.resolveColumnName(columnFullName);
+        rewriter.replace(ctx.uid().get(0).getStart(), ctx.uid().get(0).getStop(), StringUtil.quote(columnFullName, '"'));
+        rewriteColumnDefinition(columnFullName, ctx.columnDefinition());
+    }
+    private void rewriteAlterByChangeColumn(MySqlParser.AlterByChangeColumnContext ctx) {
+        final TableId tableId = context.get(TABLE_ID);
+        final ParserRuleContext parserRuleContext = context.get(PARSE_RULE_CONTEXT);
+        String oldColumnName = StringUtil.quote(ctx.oldColumn.getText(), '"');
+        String newColumnName = StringUtil.quote(ctx.newColumn.getText(), '"');
+        rewriter.insertBefore(parserRuleContext.getStart(), String.format(ALTER_TABLE_COLUMN_NAME, tableId, oldColumnName, newColumnName));
+        rewriter.replace(ctx.CHANGE().getSymbol(), "ALTER");
+        rewriter.delete(ctx.oldColumn.getStart(), ctx.oldColumn.getStop());
+        rewriter.insertBefore(ctx.columnDefinition().getStart(), "TYPE ");
+        rewriteColumnDefinition(newColumnName, ctx.columnDefinition());
+    }
+    private void rewriteAlterByModifyColumn(MySqlParser.AlterByModifyColumnContext ctx) {
+        rewriter.replace(ctx.MODIFY().getSymbol(), "ALTER");
+        List<String> fullColumnNames = new ArrayList<>(ctx.uid().size());
+        for (MySqlParser.UidContext uidContext : ctx.uid()) {
+            rewriter.replace(uidContext.getStart(), uidContext.getStop(),
+                    StringUtil.quote(StringUtil.unquote(uidContext.getText(), '`'), '"'));
+            fullColumnNames.add(uidContext.getText());
+        }
+        rewriter.insertBefore(ctx.columnDefinition().getStart(), "TYPE ");
+        for (String fullColumnName : fullColumnNames) {
+            rewriteColumnDefinition(fullColumnName, ctx.columnDefinition());
+        }
+    }
+
+    private void rewriteColumnDefinition(String fullColumnName, MySqlParser.ColumnDefinitionContext ctx) {
+        final ParserRuleContext parserRuleContext = context.get(PARSE_RULE_CONTEXT);
+        List<MySqlParser.ColumnConstraintContext> columnConstraintContexts = ctx.columnConstraint();
+        for (MySqlParser.ColumnConstraintContext columnConstraintContext : columnConstraintContexts) {
+            if (columnConstraintContext instanceof MySqlParser.PrimaryKeyColumnConstraintContext) {
+                rewriter.replace(columnConstraintContext.getStart(), columnConstraintContext.getStop(), "PRIMARY KEY");
+            }
+            if (columnConstraintContext instanceof MySqlParser.UniqueKeyColumnConstraintContext) {
+                rewriter.replace(columnConstraintContext.getStart(), columnConstraintContext.getStop(), "UNIQUE");
+            }
+            if (columnConstraintContext instanceof MySqlParser.CommentColumnConstraintContext) {
+                rewriteCommentConstraint((MySqlParser.CommentColumnConstraintContext) columnConstraintContext, fullColumnName);
+            }
+            if (columnConstraintContext instanceof MySqlParser.AutoIncrementColumnConstraintContext) {
+                rewriteAutoIncrementColumnConstraint((MySqlParser.AutoIncrementColumnConstraintContext) columnConstraintContext, fullColumnName);
+            }
+            if (columnConstraintContext instanceof MySqlParser.DefaultColumnConstraintContext) {
+                rewriteDefaultColumnConstraint((MySqlParser.DefaultColumnConstraintContext) columnConstraintContext);
+            }
+        }
+        rewriteDataType(parserRuleContext, fullColumnName, ctx.dataType());
+    }
+
+    private void rewriteDefaultColumnConstraint(MySqlParser.DefaultColumnConstraintContext ctx) {
+        MySqlParser.DefaultValueContext defaultValueContext = ctx.defaultValue();
+        if (defaultValueContext.ON() != null) {
+            comment(defaultValueContext.ON().getSymbol(), ctx.getStop());
+        }
+    }
+
+    private void rewriteAutoIncrementColumnConstraint(MySqlParser.AutoIncrementColumnConstraintContext ctx, String fullColumnName) {
+        TableId tableId = context.get(TABLE_ID);
+        MySqlParser.TableOptionAutoIncrementContext tableOptionAutoIncrementContext = context.get(TABLE_OPTION_AUTOINCREMENT_CONTEXT);
+        String columnName = columnNamingStrategy.resolveColumnName(StringUtil.unquote(fullColumnName));
+        String sequenceName = tableId.getTable() + "_" + columnName + "_sequence";
+        long initialValue = 1;
+        if (tableOptionAutoIncrementContext != null
+                && tableOptionAutoIncrementContext.decimalLiteral() != null
+                && tableOptionAutoIncrementContext.decimalLiteral().DECIMAL_LITERAL() != null) {
+            initialValue = Long.parseLong(tableOptionAutoIncrementContext.decimalLiteral().DECIMAL_LITERAL().getText());
+        }
+        beforeStatements.add(String.format(CREATE_SEQUENCE_TEMPLATE, StringUtil.quote(sequenceName, '"'), initialValue, initialValue));
+        afterStatements.add(String.format(ALTER_SEQUENCE_OWNER_TEMPLATE, StringUtil.quote(sequenceName, '"'),
+            StringUtil.quote(tableId.getTable(), '"'), StringUtil.quote(columnName, '"')));
+        rewriter.replace(ctx.getStart(), ctx.getStop(), String.format("default nextval('%s')", sequenceName));
+    }
+
+    private void rewriteCommentConstraint(MySqlParser.CommentColumnConstraintContext columnConstraintContext, String fullColumnName) {
+        TableId tableId = context.get(TABLE_ID);
+        String columnName = StringUtil.quote(fullColumnName, '"');
+        String comment = columnConstraintContext.STRING_LITERAL().getText();
+        rewriter.delete(columnConstraintContext.getStart(), columnConstraintContext.getStop());
+        afterStatements.add(String.format(CREATE_COMMENT_ON_COLUMN_TEMPLATE,
+                StringUtil.quote(tableId.getTable(), '"'), columnName, comment));
+    }
+
+    @Override
+    public void enterTableOptionComment(MySqlParser.TableOptionCommentContext ctx) {
+        TableId tableId = context.get(TABLE_ID);
+        String comment = ctx.STRING_LITERAL().getText();
+        rewriter.delete(ctx.getStart(), ctx.getStop());
+        afterStatements.add(String.format(CREATE_COMMENT_ON_TABLE_TEMPLATE,
+                StringUtil.quote(tableId.getTable(), '"') , comment));
+    }
+
+    @Override
+    public void enterTableOptionRowFormat(MySqlParser.TableOptionRowFormatContext ctx) {
+        comment(ctx.getStart(), ctx.getStop());
+    }
+
+    @Override
+    public void exitTableOptionAutoIncrement(MySqlParser.TableOptionAutoIncrementContext ctx) {
+        comment(ctx.getStart(), ctx.getStop());
+    }
+
+    @Override
+    public void exitTableOptionAutoextendSize(MySqlParser.TableOptionAutoextendSizeContext ctx) {
+        comment(ctx.getStart(), ctx.getStop());
+    }
+    private void rewriteDataType(ParserRuleContext parserRuleContext, String fullColumnName, MySqlParser.DataTypeContext dataTypeContext) {
+        if (dataTypeContext instanceof MySqlParser.DimensionDataTypeContext) {
+            rewriteDimensionDataType((MySqlParser.DimensionDataTypeContext) dataTypeContext);
+        }
+        if (dataTypeContext instanceof MySqlParser.StringDataTypeContext) {
+            rewriteStringDataTypeContext((MySqlParser.StringDataTypeContext) dataTypeContext);
+        }
+        if (dataTypeContext instanceof MySqlParser.CollectionDataTypeContext) {
+            rewriteCollectionDataType(fullColumnName, (MySqlParser.CollectionDataTypeContext) dataTypeContext);
+        }
+        if (dataTypeContext instanceof MySqlParser.SimpleDataTypeContext) {
+            rewriteSimpleDataType((MySqlParser.SimpleDataTypeContext) dataTypeContext);
+        }
+    }
+
+    private void rewriteSimpleDataType(MySqlParser.SimpleDataTypeContext ctx) {
+        if (MySqlDataTypeToPGMap.contains(ctx.typeName.getType())) {
+            rewriter.replace(ctx.getStart(), ctx.getStop(), MySqlDataTypeToPGMap.get(ctx.typeName.getType()));
+        }
+    }
+
+    @Override
+    public void exitTableOptionCharset(MySqlParser.TableOptionCharsetContext ctx) {
+        comment(ctx.getStart(),ctx.getStop());
+    }
+
+    private List<String> getColumnNamesFromIndexColumnNameContext(MySqlParser.IndexColumnNamesContext ctx) {
+        List<String> columnNames = new ArrayList<>(ctx.indexColumnName().size());
+        for (MySqlParser.IndexColumnNameContext indexColumnNameContext : ctx.indexColumnName()) {
+            String columnName = indexColumnNameContext.uid().getText();
+            rewriter.replace(indexColumnNameContext.uid().getStart(), indexColumnNameContext.uid().getStop(), StringUtil.quote(columnName, '"'));
+            if (indexColumnNameContext.sortType != null) {
+                columnName = StringUtil.quote(StringUtil.unquote(columnName, '`'), '"') + " " + indexColumnNameContext.sortType.getText();
+            } else {
+                columnName = StringUtil.quote(StringUtil.unquote(columnName, '`'), '"');
+            }
+            columnNames.add(columnNamingStrategy.resolveColumnName(columnName));
+        }
+        return columnNames;
+    }
+
+
+    @Override
+    public void exitCreateProcedure(MySqlParser.CreateProcedureContext ctx) {
+        ctx.procedureParameter();
+        MySqlParser.BlockStatementContext blockStatementContext = ctx.routineBody().blockStatement();
+        List<MySqlParser.DeclareVariableContext> declareVariableContexts = blockStatementContext.declareVariable();
+        for (MySqlParser.DeclareVariableContext declareVariableContext :  declareVariableContexts) {
+            declareVariableContext.dataType();
+        }
+    }
+
+}

--- a/src/main/java/io/dbsink/connector/sink/ddl/listener/ParserErrorListener.java
+++ b/src/main/java/io/dbsink/connector/sink/ddl/listener/ParserErrorListener.java
@@ -1,0 +1,19 @@
+package io.dbsink.connector.sink.ddl.listener;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+
+/**
+ * Parser error listener, throw exception when syntax error occurs
+ *
+ * @author Wang Wei
+ * @time: 2023-07-22
+ */
+public class ParserErrorListener extends BaseErrorListener {
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+        throw new ParseCancellationException("Syntax error at line " + line + ", position " + charPositionInLine + ": " + msg);
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/dialect/DatabaseDialect.java
+++ b/src/main/java/io/dbsink/connector/sink/dialect/DatabaseDialect.java
@@ -171,4 +171,6 @@ public interface DatabaseDialect {
         ColumnDefinition columnDefinition,
         int index
     ) throws SQLException;
+
+    DatabaseType databaseType();
 }

--- a/src/main/java/io/dbsink/connector/sink/dialect/DatabaseType.java
+++ b/src/main/java/io/dbsink/connector/sink/dialect/DatabaseType.java
@@ -1,0 +1,7 @@
+package io.dbsink.connector.sink.dialect;
+
+public enum DatabaseType {
+    MYSQL,
+    ORACLE,
+    POSTGRES
+}

--- a/src/main/java/io/dbsink/connector/sink/dialect/MySqlDialect.java
+++ b/src/main/java/io/dbsink/connector/sink/dialect/MySqlDialect.java
@@ -132,6 +132,11 @@ public class MySqlDialect extends CommonDatabaseDialect {
     }
 
     @Override
+    public DatabaseType databaseType() {
+        return DatabaseType.MYSQL;
+    }
+
+    @Override
     protected Properties getJdbcProperties() {
         Properties properties = new Properties();
         properties.put("serverTimezone", "GMT");

--- a/src/main/java/io/dbsink/connector/sink/dialect/PostgreSqlDialect.java
+++ b/src/main/java/io/dbsink/connector/sink/dialect/PostgreSqlDialect.java
@@ -110,6 +110,10 @@ public class PostgreSqlDialect extends CommonDatabaseDialect {
     public SQLState resolveSQLState(String sqlState) {
         if ("23505".equals(sqlState)) {
             return SQLState.ERR_DUP_KEY;
+        } else if ("42P07".equals(sqlState)) {
+            return SQLState.ERR_RELATION_EXISTS_ERROR;
+        } else if ("42P01".equals(sqlState)) {
+            return SQLState.ERR_RELATION_NOT_EXISTS_ERROR;
         }
         return super.resolveSQLState(sqlState);
     }
@@ -261,6 +265,11 @@ public class PostgreSqlDialect extends CommonDatabaseDialect {
         final String schema = tableId.getSchema();
         final String table = tableId.getTable();
         return new TableId(null, schema != null ? schema : catalog, table);
+    }
+
+    @Override
+    public DatabaseType databaseType() {
+        return DatabaseType.POSTGRES;
     }
 
     public static class PostgreSqlDialectProvider implements DatabaseDialectProvider {

--- a/src/main/java/io/dbsink/connector/sink/event/ChangeEvent.java
+++ b/src/main/java/io/dbsink/connector/sink/event/ChangeEvent.java
@@ -5,6 +5,8 @@
  */
 package io.dbsink.connector.sink.event;
 
+import io.dbsink.connector.sink.dialect.DatabaseType;
+
 /**
  * Change Event equivalent to ChangeEvent.
  * See #io.debezium.engine.ChangeEvent
@@ -16,6 +18,8 @@ public abstract class ChangeEvent {
     protected String topic;
     protected long offset;
     protected Integer partition;
+
+    protected DatabaseType databaseType;
 
     public String getTopic() {
         return topic;
@@ -30,4 +34,9 @@ public abstract class ChangeEvent {
     }
 
     public abstract String getTransactionId();
+
+    public DatabaseType getDatabaseType() {
+        return databaseType;
+    }
+
 }

--- a/src/main/java/io/dbsink/connector/sink/event/DataChangeEvent.java
+++ b/src/main/java/io/dbsink/connector/sink/event/DataChangeEvent.java
@@ -5,6 +5,7 @@
  */
 package io.dbsink.connector.sink.event;
 
+import io.dbsink.connector.sink.dialect.DatabaseType;
 import io.dbsink.connector.sink.relation.FieldsMetaData;
 import io.dbsink.connector.sink.relation.TableId;
 
@@ -78,6 +79,8 @@ public class DataChangeEvent extends ChangeEvent {
 
         private FieldsMetaData fieldsMetaData;
 
+        private DatabaseType databaseType;
+
         private Builder() {
         }
 
@@ -128,6 +131,11 @@ public class DataChangeEvent extends ChangeEvent {
             return this;
         }
 
+        public Builder databaseType(DatabaseType databaseType) {
+            this.databaseType = databaseType;
+            return this;
+        }
+
         public DataChangeEvent build() {
             DataChangeEvent dataChangeEvent = new DataChangeEvent();
             dataChangeEvent.fieldsMetaData = this.fieldsMetaData;
@@ -139,6 +147,7 @@ public class DataChangeEvent extends ChangeEvent {
             dataChangeEvent.afterValues = this.afterValues;
             dataChangeEvent.topic = this.topic;
             dataChangeEvent.transactionId = this.transactionId;
+            dataChangeEvent.databaseType = this.databaseType;
             return dataChangeEvent;
         }
     }

--- a/src/main/java/io/dbsink/connector/sink/event/SchemaChangeEvent.java
+++ b/src/main/java/io/dbsink/connector/sink/event/SchemaChangeEvent.java
@@ -5,6 +5,7 @@
  */
 package io.dbsink.connector.sink.event;
 
+import io.dbsink.connector.sink.dialect.DatabaseType;
 import io.dbsink.connector.sink.relation.TableId;
 
 /**
@@ -44,6 +45,8 @@ public class SchemaChangeEvent extends ChangeEvent {
         private long offset;
         private Integer partition;
 
+        private DatabaseType databaseType;
+
         private String transactionId;
 
         private Builder() {
@@ -80,6 +83,11 @@ public class SchemaChangeEvent extends ChangeEvent {
             return this;
         }
 
+        public Builder databaseType(DatabaseType databaseType) {
+            this.databaseType = databaseType;
+            return this;
+        }
+
         public SchemaChangeEvent build() {
             SchemaChangeEvent schemaChangeEvent = new SchemaChangeEvent();
             schemaChangeEvent.tableId = this.tableId;
@@ -87,6 +95,7 @@ public class SchemaChangeEvent extends ChangeEvent {
             schemaChangeEvent.ddl = this.ddl;
             schemaChangeEvent.offset = this.offset;
             schemaChangeEvent.topic = this.topic;
+            schemaChangeEvent.databaseType = this.databaseType;
             return schemaChangeEvent;
         }
     }

--- a/src/main/java/io/dbsink/connector/sink/naming/DefaultTableNamingStrategy.java
+++ b/src/main/java/io/dbsink/connector/sink/naming/DefaultTableNamingStrategy.java
@@ -5,6 +5,8 @@
  */
 package io.dbsink.connector.sink.naming;
 
+import io.dbsink.connector.sink.relation.TableId;
+
 /**
  * Default  table naming strategy without any changes
  *
@@ -20,7 +22,7 @@ public class DefaultTableNamingStrategy implements TableNamingStrategy {
      * @time: 2023-06-24
      */
     @Override
-    public String resolveTableName(String table) {
-        return table;
+    public TableId resolveTableId(TableId tableId) {
+        return tableId;
     }
 }

--- a/src/main/java/io/dbsink/connector/sink/naming/LowCaseTableNamingStrategy.java
+++ b/src/main/java/io/dbsink/connector/sink/naming/LowCaseTableNamingStrategy.java
@@ -5,6 +5,8 @@
  */
 package io.dbsink.connector.sink.naming;
 
+import io.dbsink.connector.sink.relation.TableId;
+
 import java.util.Locale;
 
 /**
@@ -23,7 +25,7 @@ public class LowCaseTableNamingStrategy implements TableNamingStrategy {
      * @time: 2023-06-24
      */
     @Override
-    public String resolveTableName(String table) {
-        return table.toLowerCase(Locale.ROOT);
+    public TableId resolveTableId(TableId tableId) {
+        return null;
     }
 }

--- a/src/main/java/io/dbsink/connector/sink/naming/TableNamingStrategy.java
+++ b/src/main/java/io/dbsink/connector/sink/naming/TableNamingStrategy.java
@@ -5,6 +5,8 @@
  */
 package io.dbsink.connector.sink.naming;
 
+import io.dbsink.connector.sink.relation.TableId;
+
 /**
  * Table naming strategy,used to resolve table name in target database
  * from kafka sink record{@link org.apache.kafka.connect.sink.SinkRecord}
@@ -20,5 +22,5 @@ public interface TableNamingStrategy {
      * @author Wang Wei
      * @time: 2023-06-24
      */
-    String resolveTableName(String table);
+    TableId resolveTableId(TableId tableId);
 }

--- a/src/main/java/io/dbsink/connector/sink/naming/UpperCaseTableNamingStrategy.java
+++ b/src/main/java/io/dbsink/connector/sink/naming/UpperCaseTableNamingStrategy.java
@@ -5,7 +5,10 @@
  */
 package io.dbsink.connector.sink.naming;
 
+import io.dbsink.connector.sink.relation.TableId;
+
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Upper case table naming strategy
@@ -23,7 +26,16 @@ public class UpperCaseTableNamingStrategy implements TableNamingStrategy {
      * @time: 2023-06-24
      */
     @Override
-    public String resolveTableName(String table) {
-        return table.toUpperCase(Locale.ROOT);
+    public TableId resolveTableId(TableId tableId) {
+        String catalog = Optional
+            .ofNullable(tableId.getCatalog()).map(item -> item.toUpperCase(Locale.ROOT))
+            .orElse(null);
+        String schema = Optional
+            .ofNullable(tableId.getSchema()).map(item -> item.toUpperCase(Locale.ROOT))
+            .orElse(null);
+        String table = Optional
+            .ofNullable(tableId.getTable()).map(item -> item.toUpperCase(Locale.ROOT))
+            .orElse(null);
+        return new TableId(catalog, schema, table);
     }
 }

--- a/src/main/java/io/dbsink/connector/sink/relation/TableDefinitions.java
+++ b/src/main/java/io/dbsink/connector/sink/relation/TableDefinitions.java
@@ -62,4 +62,13 @@ public class TableDefinitions {
         tableDefinitionCache.put(tableId, tableDefinition);
         return tableDefinition;
     }
+
+    public synchronized void refresh(Connection connection, TableId tableId) throws SQLException {
+        tableDefinitionCache.remove(tableId);
+        TableDefinition tableDefinition = databaseDialect.readTable(connection, tableId);
+        if (tableDefinition == null) {
+            return;
+        }
+        tableDefinitionCache.put(tableId, tableDefinition);
+    }
 }

--- a/src/main/java/io/dbsink/connector/sink/relation/TableId.java
+++ b/src/main/java/io/dbsink/connector/sink/relation/TableId.java
@@ -26,10 +26,13 @@ public class TableId implements ExpressibleObject {
     private String schema;
     private String table;
 
+    private final String id;
+
     public TableId(String catalog, String schema, String table) {
         this.catalog = catalog;
         this.schema = schema;
         this.table = table;
+        this.id = tableId(catalog, schema, table);
     }
     public String getCatalog() {
         return catalog;
@@ -64,6 +67,35 @@ public class TableId implements ExpressibleObject {
         }
     }
 
+    public TableId toQuoted(char quotingChar) {
+        String catalogName = null;
+        if (this.catalog != null && !this.catalog.isEmpty()) {
+            catalogName = StringUtil.quote(this.catalog, quotingChar);
+        }
+
+        String schemaName = null;
+        if (this.schema != null && !this.schema.isEmpty()) {
+            schemaName = StringUtil.quote(this.schema, quotingChar);
+        }
+
+        return new TableId(catalogName, schemaName, StringUtil.quote(this.table, quotingChar));
+    }
+
+    private static String tableId(String catalog, String schema, String table) {
+        if (catalog == null || catalog.length() == 0) {
+            if (schema == null || schema.length() == 0) {
+                return table;
+            }
+            return schema + "." + table;
+        }
+        if (schema == null || schema.length() == 0) {
+            return catalog + "." + table;
+        }
+        return catalog + "." + schema + "." + table;
+    }
+    public String identifier() {
+        return id;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/io/dbsink/connector/sink/util/Pair.java
+++ b/src/main/java/io/dbsink/connector/sink/util/Pair.java
@@ -1,0 +1,62 @@
+package io.dbsink.connector.sink.util;
+
+import java.util.Objects;
+
+/**
+ * A simple generic class representing a pair of values.
+ *
+ * @param <K> the type of the first value
+ * @param <V> the type of the second value
+ * @author Wang Wei
+ * @time: 2023-07-16
+ */
+public class Pair<K, V> {
+    private K first;
+    private V second;
+
+    private Pair(K first, V second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    /**
+     * Returns the first value of the pair.
+     *
+     * @return the first value
+     */
+    public K getFirst() {
+        return first;
+    }
+
+    /**
+     * Returns the second value of the pair.
+     *
+     * @return the second value
+     */
+    public V getSecond() {
+        return second;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+        return Objects.equals(first, pair.first) && Objects.equals(second, pair.second);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(first, second);
+    }
+
+    /**
+     * Constructs a new Pair object with the specified values.
+     *
+     * @param first  the first value of the pair
+     * @param second the second value of the pair
+     */
+    public static <K, V> Pair of(K first, V second) {
+        return new Pair<>(first, second);
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/util/RelationMappings.java
+++ b/src/main/java/io/dbsink/connector/sink/util/RelationMappings.java
@@ -1,0 +1,54 @@
+package io.dbsink.connector.sink.util;
+
+import io.dbsink.connector.sink.relation.TableId;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The mapping relationships between the source database and
+ * the target database for tables and columns
+ *
+ * @author: Wang Wei
+ * @time: 2023-07-16
+ */
+public class RelationMappings {
+    private final Map<TableId, Map<String, String>> columnMappings;
+
+    private final Map<TableId, TableId> tableMappings;
+
+    public RelationMappings() {
+        this.columnMappings = new HashMap<>();
+        this.tableMappings = new HashMap<>();
+    }
+
+    public void addColumMapping(TableId tableId, String sourceColumnName, String targetColumnName) {
+        Map<String,String> columnMapping = columnMappings.get(tableId);
+        if (columnMapping == null) {
+            columnMapping = new HashMap<>();
+            columnMappings.put(tableId, columnMapping);
+        }
+        columnMapping.put(sourceColumnName, targetColumnName);
+    }
+
+    public void addTableMapping(TableId sourceTableId, TableId targetTableId) {
+        tableMappings.put(sourceTableId, targetTableId);
+    }
+
+    public TableId convert(TableId tableId) {
+        TableId target = tableMappings.get(tableId);
+        return target;
+    }
+
+    public String convert(TableId tableId, String columName) {
+        Map<String,String> columnMapping = columnMappings.get(tableId);
+        if (columnMapping == null) {
+            return null;
+        }
+        String targetColumnName = columnMapping.get(columName);
+        if (targetColumnName == null) {
+            return null;
+        }
+        return targetColumnName;
+    }
+}

--- a/src/main/java/io/dbsink/connector/sink/util/StringUtil.java
+++ b/src/main/java/io/dbsink/connector/sink/util/StringUtil.java
@@ -9,6 +9,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.bson.types.Binary;
 
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /**
  * String util
@@ -18,7 +19,7 @@ import java.nio.ByteBuffer;
  */
 public class StringUtil {
     /**
-     * Quote sql identifier
+     * Quote sql identifier with the specified quote
      *
      * @param identifier sql identifier
      * @param quote      quote
@@ -27,6 +28,97 @@ public class StringUtil {
      */
     public static String quote(String identifier, String quote) {
         return quote + identifier.replace(quote, quote + quote) + quote;
+    }
+
+    /**
+     * Quote sql identifier with the specified quote
+     *
+     * @param identified sql identifier
+     * @param quote      quote
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static String quote(String identified, char quote) {
+        if (identified.charAt(0) == quote && identified.charAt(identified.length() - 1) == quote) {
+            return identified;
+        }
+        if (isQuoted(identified)) {
+            identified = unquote(identified);
+        }
+        return quote + identified + quote;
+    }
+
+    /**
+     * Get the quote character of the SQL identifier if possible
+     *
+     * @param identifier SQL identifier
+     * @return the quote character if possible
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static Optional<Character> getQuote(String identifier) {
+        if (isQuoted(identifier)) {
+            return Optional.of(identifier.charAt(0));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Remove the quote from a SQL identifier with the specified quote
+     *
+     * @param identifier SQL identifier
+     * @param quote      quote
+     * @return SQL identifier without the quote
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static String unquote(String identifier, char quote) {
+        if (identifier.charAt(0) == quote && identifier.charAt(identifier.length() - 1) == quote) {
+            return identifier.substring(1, identifier.length() - 1);
+        }
+        return identifier;
+    }
+
+    /**
+     * Remove the quote from a SQL identifier
+     *
+     * @param identifier SQL identifier
+     * @return SQL identifier without the quote
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static String unquote(String identifier) {
+        Optional<Character> optional = getQuote(identifier);
+        if (!optional.isPresent()) {
+            return identifier;
+        }
+        char quota = optional.get();
+        identifier.replace(quota + "" + quota, quota + "");
+        return identifier.substring(1, identifier.length() - 1);
+    }
+
+    /**
+     * judge if a SQL identifier is quoted
+     *
+     * @param identifier
+     * @return if a SQL identifier is quoted
+     * @author Wang Wei
+     * @time: 2023-07-22
+     */
+    public static boolean isQuoted(String identifier) {
+        if (identifier.length() <= 2) {
+            return false;
+        }
+        if (identifier.charAt(0) == '"' && identifier.charAt(identifier.length() - 1) == '"') {
+            return true;
+        }
+        if (identifier.charAt(0) == '`' && identifier.charAt(identifier.length() - 1) == '`') {
+            return true;
+        }
+        if (identifier.charAt(0) == '\'' && identifier.charAt(identifier.length() - 1) == '\'') {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/io/dbsink/connector/sink/util/WorkerThread.java
+++ b/src/main/java/io/dbsink/connector/sink/util/WorkerThread.java
@@ -80,7 +80,7 @@ public abstract class WorkerThread implements Runnable {
     public final void run() {
         try {
             execute();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             if (isStopping) {
                 LOGGER.trace("Worker thread is interrupted", e);
             } else {

--- a/src/main/resources/META-INF/services/io.dbsink.connector.sink.ddl.converters.SQLConverterProvider
+++ b/src/main/resources/META-INF/services/io.dbsink.connector.sink.ddl.converters.SQLConverterProvider
@@ -1,0 +1,1 @@
+io.dbsink.connector.sink.ddl.converters.MySqlToPGConverter$MySqlToPGConverterProvider

--- a/src/test/java/io/dbsink/connector/sink/ddl/TestMySqlToPG.java
+++ b/src/test/java/io/dbsink/connector/sink/ddl/TestMySqlToPG.java
@@ -1,0 +1,98 @@
+package io.dbsink.connector.sink.ddl;
+
+import io.dbsink.connector.sink.ddl.converters.ConversionConfiguration;
+import io.dbsink.connector.sink.ddl.converters.ConversionResult;
+import io.dbsink.connector.sink.ddl.converters.SQLConverter;
+import io.dbsink.connector.sink.ddl.converters.SQLConverters;
+import io.dbsink.connector.sink.dialect.DatabaseType;
+import io.dbsink.connector.sink.naming.DefaultTableNamingStrategy;
+import io.dbsink.connector.sink.naming.UpperCaseColumnNamingStrategy;
+import io.dbsink.connector.sink.naming.UpperCaseTableNamingStrategy;
+import io.dbsink.connector.sink.relation.TableId;
+import io.dbsink.connector.sink.util.StringUtil;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TestMySqlToPG {
+    private static TableId parseTableId(String identifier) {
+        Pattern pattern = Pattern.compile("(.+)(\\.(.+))?");
+        Matcher matcher = pattern.matcher(identifier);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("sd");
+        }
+        String catalogName;
+        String tableName;
+        if (matcher.group(2) != null) {
+            catalogName = StringUtil.unquote(matcher.group(1), '`');
+            tableName = StringUtil.unquote(matcher.group(2), '`');
+        } else {
+            catalogName = null;
+            tableName = StringUtil.unquote(matcher.group(1), '`');
+        }
+        return new TableId(catalogName, null, tableName);
+
+    }
+
+    public static String[] parseSQLIdentifier(String identifier, char delimiter) {
+        boolean isInBlank = false;
+        for (int i = 0; i < identifier.length(); i++) {
+            char c = identifier.charAt(i);
+            if (c == delimiter) {
+                if (!isInBlank) {
+                    isInBlank = true;
+                } else if (i < identifier.length() - 1 && identifier.charAt(i + 1) == delimiter) {
+                    i++;
+                } else {
+                    isInBlank = false;
+                }
+            }
+        }
+        String[] result = new String[2];
+
+        Pattern pattern = Pattern.compile(delimiter + "([^" + delimiter + "]+)" + delimiter + "\\." + delimiter + "([^" + delimiter + "]+)" + delimiter);
+        Matcher matcher = pattern.matcher(identifier);
+
+        if (matcher.find()) {
+            result[0] = matcher.group(1);
+            result[1] = matcher.group(2);
+        }
+
+        return result;
+    }
+
+    public static void main(String[] args) {
+        String identified = "`test`.`tat1`";
+        String delimiter = "\"";
+        String tmp = "\"\"";
+        System.out.println(tmp.replace("\"\"", "\""));
+        TableId tableId = parseTableId(identified);
+        ConversionConfiguration configuration = new ConversionConfiguration(new UpperCaseTableNamingStrategy(), new UpperCaseColumnNamingStrategy());
+        SQLConverter sqlConverter = SQLConverters.create(DatabaseType.MYSQL, DatabaseType.POSTGRES, configuration);
+
+        String sql = "CREATE TABLE `auth_account` (\n" +
+            "  `uid` bigint unsigned NOT NULL COMMENT '全平台用户唯一id',\n" +
+            "  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',\n" +
+            "  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',\n" +
+            "  `username` varchar(30) CHARACTER SET utf8mb4 NOT NULL DEFAULT '' COMMENT '用户名',\n" +
+            "  `password` varchar(64) CHARACTER SET utf8mb4  NOT NULL DEFAULT '' COMMENT '密码',\n" +
+            "  `create_ip` varchar(15) CHARACTER SET utf8mb4  NOT NULL DEFAULT '' COMMENT '创建ip',\n" +
+            "  `status` tinyint NOT NULL COMMENT '状态 1:启用 0:禁用 -1:删除',\n" +
+            "  `sys_type` tinyint NOT NULL COMMENT '用户类型见SysTypeEnum 0.普通用户系统 1.商家端 2平台端',\n" +
+            "  `user_id` bigint NOT NULL COMMENT '用户id',\n" +
+            "  `tenant_id` bigint DEFAULT NULL COMMENT '所属租户',\n" +
+            "  `is_admin` tinyint DEFAULT NULL COMMENT '是否是管理员',\n" +
+            "  PRIMARY KEY (`uid`) USING BTREE,\n" +
+            "  UNIQUE KEY `uk_usertype_userid` (`sys_type`,`user_id`) USING BTREE,\n" +
+            "  KEY `idx_username` (`username`) USING BTREE\n" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='统一账户信息'";
+       // String sql = "create table tmp(col1 int primary key auto_increment,col2 varchar(10), KEY `idx_attr` (`col2`) USING BTREE)";
+        //String sql = "create table tmp(col1 int primary key,col2 varchar(10), KEY `idx_attr` (`col2`) USING BTREE)";
+       // String sql = "alter table student add `chengji` int not null;";
+        ConversionResult conversionResult = sqlConverter.convert(sql);
+        for (String statement : conversionResult.getStatements()) {
+            System.out.println(statement);
+        }
+        System.out.println("sdf");
+    }
+}


### PR DESCRIPTION
1. Add sql parser(based on antlr) to convert ddl statement from MySQL to PostgreSQL
2. Add exception handling mechanism for DDL replay. When replaying ddl statement, if a SQL Exception occurs including  "relation does not exist” or  "relation already exists" , it should be skipped, as these exceptions are caused by duplicate consumption.

self-test:
MySQL
![image](https://github.com/1149782339/DbSink/assets/43700998/bd9c4a1b-acc4-4a51-8680-28c298e6371e)

Sink Connector Log
![image](https://github.com/1149782339/DbSink/assets/43700998/66421df5-1f5c-4f5c-b25d-4c148a4d5ecc)

Postgres
![image](https://github.com/1149782339/DbSink/assets/43700998/1dea3905-b855-4573-8a71-f3f829e63cea)

It is evident that we have successfully translated MySQL DDL statements into PostgreSQL DDL statements and successfully replayed them in the target database.
